### PR TITLE
fix: Hydrator コンポーネントのリファクタリングとバグ修正

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,6 +22,14 @@
         "noUndeclaredDependencies": "off",
         "useImportExtensions": "off"
       },
+      "style": {
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": false
+          }
+        }
+      },
       "suspicious": {
         "noConsole": {
           "level": "warn",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 export const ENV = {
   /** アプリケーション名 */


### PR DESCRIPTION
## 変更内容

1. Biomeの設定修正
   - `useNamingConvention` ルールの `strictCase` オプションを `false` に設定
   - 型パラメータで連続した大文字（例：`TQueryFnData`）を許可

2. Hydratorコンポーネントの改善
   - JSDocコメントの追加
   - 変数名の改善
   - `try/finally` ブロックの追加
   - `queryClient.clear()` の追加によるリソースの確実なクリーンアップ

3. Zodのインポート方法を修正
   - `import z from "zod"` から `import { z } from "zod"` に変更

## 期待される効果
- コードの品質と保守性の向上
- 型定義の明確化
- メモリリークの防止
- 例外発生時のリソース解放の保証