### PR TITLE
chore(renovate): group patch updates into single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,7 @@
   },
   "packageRules": [
     {
+      "groupName": "patch dependencies",
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "platformAutomerge": true


### PR DESCRIPTION
## Summary
- パッチバージョンのアップデートを1つのPRにまとめるように設定を追加

## Changes
- `packageRules`のpatchアップデートに`groupName: "patch dependencies"`を追加
- これにより0.0.xなどのパッチアップデートが個別ではなく1つのPRとして作成される

## Test plan
- [ ] Renovateが次回実行時にパッチアップデートをグループ化することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)