### PR TITLE
fix: Renovate automerge設定の改善

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,19 +14,13 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["after 10pm on sunday", "before 5am on sunday"],
-    "commitMessageAction": "Update",
-    "commitMessageTopic": "lock file maintenance"
+    "automergeType": "branch",
+    "schedule": ["after 10pm on sunday", "before 5am on sunday"]
   },
   "packageRules": [
     {
       "groupName": "patch dependencies",
       "matchUpdateTypes": ["patch"]
-    },
-    {
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "automergeType": "branch",
-      "automergeStrategy": "merge-commit"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- lockFileMaintenanceブロックに`automergeType: "branch"`を追加
- packageRulesから重複していたlockFileMaintenance設定を削除
- 不要なcommitMessage設定を削除してシンプルに

## 変更理由
GitHub Actionsの「Allow auto-merge」が有効になったため、branch automergeが使用できるようになりました。これにより、ロックファイル更新時にPRを作成せず、テストが通れば直接mainブランチにマージされます。

## Test plan
- [ ] Renovateの設定検証が通ること
- [ ] 次回のlockFileMaintenance実行時に正常に動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)