### PR TITLE
chore: remove CSS assist configuration from Biome

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -14,11 +14,6 @@
       }
     }
   },
-  "css": {
-    "assist": {
-      "enabled": true
-    }
-  },
   "files": {
     "ignoreUnknown": true,
     "includes": ["**", "!public", "!src/api/openapi"]


### PR DESCRIPTION
## Summary
- BiomeのCSS assist設定を削除しました
- 現在のセットアップではこの設定は不要となったため

## Test plan
- [ ] biome.jsonc設定ファイルが正常に動作することを確認
- [ ] `pnpm lint:biome`が正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)