### PR TITLE
chore: use fully-qualified aqua backend for zizmor in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 actionlint = "1.7.12"
 node = "24.14.1"
 pnpm = "10.33.0"
-zizmor = "1.24.1"
+"aqua:zizmorcore/zizmor" = "1.24.1"


### PR DESCRIPTION
## Summary

- `mise.toml` の `zizmor = "1.24.1"` を `"aqua:zizmorcore/zizmor" = "1.24.1"` に変更し、Renovate が zizmor の更新を検知できるようにする
- mise 側の既定解決先 (`mise registry zizmor` → `aqua:zizmorcore/zizmor`) と同一のためインストール挙動は無変更

## Why

Renovate の `mise` manager は [mise registry を動的参照せず、ハードコードされた短縮名リストから datasource を解決する仕様](https://docs.renovatebot.com/modules/manager/mise/#short-names-support) (> "Support for new tool short names needs to be _manually_ added to Renovate's logic")。`zizmor` はそのリストに未登録のため、他ツール (node / pnpm / actionlint) と違い更新 PR が出ていなかった。バックエンドをフル修飾で書けば Renovate の aqua バックエンドサポート経由で GithubTagsDatasource として検知される。

## Test plan

- [x] `mise install` が成功し zizmor 1.24.1 がインストールされる
- [x] `mise exec -- zizmor --version` が `zizmor 1.24.1` を返す
- [ ] マージ後、次回 Renovate スキャンで `aqua:zizmorcore/zizmor` の更新 PR が出ることを確認 (Dependency Dashboard で force refetch 可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)