### PR TITLE
feat(hooks): add useSessionStorage with shared useWebStorage core

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -88,11 +88,13 @@ export default defineConfig({
     "import/unambiguous": "off",
 
     // ── eslint-plugin-jsdoc (built-in) ──
+    // TS ファイルではシグネチャに型があるため JSDoc の型は重複（ts(80004)）。
     "jsdoc/require-param": "off",
     "jsdoc/require-param-description": "off",
     "jsdoc/require-param-type": "off",
     "jsdoc/require-returns": "off",
     "jsdoc/require-returns-description": "off",
+    "jsdoc/require-returns-type": "off",
 
     // ── eslint-plugin-node (built-in) ──
     "node/no-process-env": "off",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -88,7 +88,6 @@ export default defineConfig({
     "import/unambiguous": "off",
 
     // ── eslint-plugin-jsdoc (built-in) ──
-    // TS ファイルではシグネチャに型があるため JSDoc の型は重複（ts(80004)）。
     "jsdoc/require-param": "off",
     "jsdoc/require-param-description": "off",
     "jsdoc/require-param-type": "off",

--- a/src/app/(sandbox)/dummy/page.tsx
+++ b/src/app/(sandbox)/dummy/page.tsx
@@ -10,6 +10,7 @@ import { useDisclosure } from "../../../hooks/useDisclosure";
 import { useIsComposing } from "../../../hooks/useIsComposing";
 import { useLocalStorage } from "../../../hooks/useLocalStorage";
 import { useMediaQuery } from "../../../hooks/useMediaQuery";
+import { useSessionStorage } from "../../../hooks/useSessionStorage";
 import { createCustomEvent } from "../../../utils/createCustomEvent";
 import { isKeyOf } from "../../../utils/isKeyOf";
 import { isValueOf } from "../../../utils/isValueOf";
@@ -21,7 +22,8 @@ export default function Page() {
     // noop
   }, 1000);
   useIsComposing();
-  useLocalStorage("dummy", "");
+  useLocalStorage("dummy");
+  useSessionStorage("dummy");
   useMediaQuery("(min-width: 768px)");
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   createCustomEvent("" as keyof GlobalEventHandlersEventMap);

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
@@ -52,7 +52,7 @@ type Story = StoryObj;
 export const Default: Story = {
   play: async ({ canvas }) => {
     const [currentValue, newValueInput] = canvas.getAllByRole("textbox");
-    await expect(currentValue).toHaveValue("initial");
+    await expect(currentValue).toHaveValue("null");
 
     await userEvent.clear(newValueInput);
     await userEvent.type(newValueInput, "saved-value");
@@ -62,6 +62,6 @@ export const Default: Story = {
     await expect(currentValue).toHaveValue("saved-value");
 
     await userEvent.click(removeButton);
-    await expect(currentValue).toHaveValue("initial");
+    await expect(currentValue).toHaveValue("null");
   },
 };

--- a/src/hooks/useLocalStorage/useLocalStorage.test.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.test.ts
@@ -31,54 +31,49 @@ describe(useLocalStorage, () => {
   });
 
   describe("基本動作", () => {
-    it("初期値を返すこと", () => {
+    it("未設定なら null を返す", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
-      expect(result.current[0]).toBe("default");
+      const { result } = renderHook(() => useLocalStorage(key));
+      expect(result.current[0]).toBeNull();
     });
 
-    it("localStorageの既存値を読み取ること", () => {
+    it("localStorageの既存値を読み取る", () => {
       const key = uniqueKey();
-      mockStorage.setItem(key, JSON.stringify("stored"));
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      mockStorage.setItem(key, "stored");
+      const { result } = renderHook(() => useLocalStorage(key));
       expect(result.current[0]).toBe("stored");
     });
 
-    it("setValueで値を更新できること", () => {
+    it("setValueで値を更新できる", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       act(() => {
         result.current[1]("updated");
       });
 
       expect(result.current[0]).toBe("updated");
-      expect(mockStorage.setItem).toHaveBeenCalledWith(
-        key,
-        JSON.stringify("updated"),
-      );
+      expect(mockStorage.setItem).toHaveBeenCalledWith(key, "updated");
     });
 
-    it("関数型更新をサポートすること", () => {
+    it("関数型更新をサポートする（prev は string | null）", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, 0));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       act(() => {
-        result.current[1]((prev) => prev + 1);
+        result.current[1]((prev) => `${prev ?? ""}a`);
       });
-
-      expect(result.current[0]).toBe(1);
+      expect(result.current[0]).toBe("a");
 
       act(() => {
-        result.current[1]((prev) => prev + 10);
+        result.current[1]((prev) => `${prev ?? ""}b`);
       });
-
-      expect(result.current[0]).toBe(11);
+      expect(result.current[0]).toBe("ab");
     });
 
-    it("removeValueで値を削除して初期値に戻ること", () => {
+    it("removeValue 後は null に戻る", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       act(() => {
         result.current[1]("stored");
@@ -89,92 +84,26 @@ describe(useLocalStorage, () => {
         result.current[2]();
       });
 
-      expect(result.current[0]).toBe("default");
+      expect(result.current[0]).toBeNull();
       expect(mockStorage.removeItem).toHaveBeenCalledWith(key);
     });
   });
 
-  describe("シリアライズ", () => {
-    it("オブジェクトを正しく保存・読み取りできること", () => {
-      const key = uniqueKey();
-      const obj = { name: "test", count: 42 };
-      const { result } = renderHook(() =>
-        useLocalStorage(key, { name: "", count: 0 }),
-      );
-
-      act(() => {
-        result.current[1](obj);
-      });
-
-      expect(result.current[0]).toStrictEqual(obj);
-    });
-
-    it("配列を正しく保存・読み取りできること", () => {
-      const key = uniqueKey();
-      const arr = [1, 2, 3];
-      const { result } = renderHook(() => useLocalStorage<number[]>(key, []));
-
-      act(() => {
-        result.current[1](arr);
-      });
-
-      expect(result.current[0]).toStrictEqual(arr);
-    });
-
-    it("数値を正しく処理すること", () => {
-      const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, 0));
-
-      act(() => {
-        result.current[1](42);
-      });
-
-      expect(result.current[0]).toBe(42);
-    });
-
-    it("nullを正しく処理すること", () => {
-      const key = uniqueKey();
-      const { result } = renderHook(() =>
-        useLocalStorage<string | null>(key, null),
-      );
-
-      expect(result.current[0]).toBeNull();
-
-      act(() => {
-        result.current[1]("value");
-      });
-      expect(result.current[0]).toBe("value");
-
-      act(() => {
-        result.current[1](null);
-      });
-      expect(result.current[0]).toBeNull();
-    });
-  });
-
   describe("エラーハンドリング", () => {
-    it("localStorage利用不可時に初期値を返すこと", () => {
+    it("localStorage 利用不可時に null を返す", () => {
       const key = uniqueKey();
       mockStorage.getItem.mockImplementation(() => {
         throw new Error("localStorage unavailable");
       });
 
-      const { result } = renderHook(() => useLocalStorage(key, "fallback"));
-      expect(result.current[0]).toBe("fallback");
+      const { result } = renderHook(() => useLocalStorage(key));
+      expect(result.current[0]).toBeNull();
     });
 
-    it("破損JSONの場合に初期値を返すこと", () => {
-      const key = uniqueKey();
-      mockStorage.setItem(key, "invalid-json{{{");
-
-      const { result } = renderHook(() => useLocalStorage(key, "fallback"));
-      expect(result.current[0]).toBe("fallback");
-    });
-
-    it("QuotaExceededError時にconsole.warnを出力し状態を変更しないこと", () => {
+    it("QuotaExceededError 時に console.warn を出力し状態を変更しない", () => {
       const key = uniqueKey();
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       mockStorage.setItem.mockImplementation(() => {
         throw new DOMException("quota exceeded", "QuotaExceededError");
@@ -185,22 +114,23 @@ describe(useLocalStorage, () => {
       });
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(result.current[0]).toBe("default");
-      // localStorage に書き込まれていないことを確認
+      expect(result.current[0]).toBeNull();
       expect(mockStorage.getItem(key)).toBeNull();
     });
   });
 
   describe("タブ間同期", () => {
-    it("storageイベントで値が更新されること", () => {
+    it("storage イベントで値が更新される", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       act(() => {
+        mockStorage.setItem(key, "from-other-tab");
         window.dispatchEvent(
           new StorageEvent("storage", {
             key,
-            newValue: JSON.stringify("from-other-tab"),
+            newValue: "from-other-tab",
+            storageArea: window.localStorage,
           }),
         );
       });
@@ -208,9 +138,9 @@ describe(useLocalStorage, () => {
       expect(result.current[0]).toBe("from-other-tab");
     });
 
-    it("storageイベントで削除を検知すること", () => {
+    it("storage イベントで削除を検知する", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       act(() => {
         result.current[1]("stored");
@@ -223,39 +153,37 @@ describe(useLocalStorage, () => {
           new StorageEvent("storage", {
             key,
             newValue: null,
+            storageArea: window.localStorage,
           }),
         );
       });
 
-      expect(result.current[0]).toBe("default");
+      expect(result.current[0]).toBeNull();
     });
 
-    it("無関係なキーのstorageイベントを無視すること", () => {
+    it("無関係なキーの storage イベントを無視する", () => {
       const key = uniqueKey();
-      const { result } = renderHook(() => useLocalStorage(key, "default"));
+      const { result } = renderHook(() => useLocalStorage(key));
 
       act(() => {
         window.dispatchEvent(
           new StorageEvent("storage", {
             key: "other-key",
-            newValue: JSON.stringify("other-value"),
+            newValue: "other-value",
+            storageArea: window.localStorage,
           }),
         );
       });
 
-      expect(result.current[0]).toBe("default");
+      expect(result.current[0]).toBeNull();
     });
   });
 
   describe("同一タブ同期", () => {
-    it("同じキーの複数インスタンスが同期すること", () => {
+    it("同じキーの複数インスタンスが同期する", () => {
       const key = uniqueKey();
-      const { result: result1 } = renderHook(() =>
-        useLocalStorage(key, "default"),
-      );
-      const { result: result2 } = renderHook(() =>
-        useLocalStorage(key, "default"),
-      );
+      const { result: result1 } = renderHook(() => useLocalStorage(key));
+      const { result: result2 } = renderHook(() => useLocalStorage(key));
 
       act(() => {
         result1.current[1]("synced");
@@ -267,18 +195,29 @@ describe(useLocalStorage, () => {
   });
 
   describe("クリーンアップ", () => {
-    it("アンマウント時にリスナーが解除されること", () => {
+    it("アンマウント後は同タブの書き込みで再レンダーされない", () => {
       const key = uniqueKey();
-      const addSpy = vi.spyOn(window, "addEventListener");
-      const removeSpy = vi.spyOn(window, "removeEventListener");
+      const renderSpy = vi.fn();
+      const { unmount } = renderHook(() => {
+        renderSpy();
+        return useLocalStorage(key);
+      });
 
-      const { unmount } = renderHook(() => useLocalStorage(key, "default"));
-
-      expect(addSpy).toHaveBeenCalledWith("storage", expect.any(Function));
-
+      const renderCountBeforeUnmount = renderSpy.mock.calls.length;
       unmount();
 
-      expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function));
+      act(() => {
+        window.localStorage.setItem(key, "after-unmount");
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key,
+            newValue: "after-unmount",
+            storageArea: window.localStorage,
+          }),
+        );
+      });
+
+      expect(renderSpy).toHaveBeenCalledTimes(renderCountBeforeUnmount);
     });
   });
 });

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,118 +1,15 @@
-import { useSyncExternalStore } from "react";
+import { localStorageStore } from "../../utils/webStorageStore";
+import { useWebStorage } from "../useWebStorage";
 
-const cache = new Map<string, string>();
-const listeners = new Map<string, Set<() => void>>();
-
-function getListeners(key: string) {
-  const existing = listeners.get(key);
-  if (existing) {
-    return existing;
-  }
-  const created = new Set<() => void>();
-  listeners.set(key, created);
-  return created;
-}
-
-function notifyListeners(key: string) {
-  for (const listener of getListeners(key)) {
-    listener();
-  }
-}
-
-function parseJSON<T>(raw: string, fallback: T): T {
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return parsed as T; // oxlint-disable-line typescript-eslint/no-unsafe-type-assertion
-  } catch {
-    return fallback;
-  }
-}
-
-function isFunction<T>(value: T | ((prev: T) => T)): value is (prev: T) => T {
-  return typeof value === "function";
-}
-
-/** SSR対応のlocalStorageフック（useSyncExternalStoreベース） */
-export function useLocalStorage<T>(
-  key: string,
-  initialValue: T,
-): [
-  value: T,
-  setValue: (value: T | ((prev: T) => T)) => void,
-  removeValue: () => void,
-] {
-  const serializedInitial = JSON.stringify(initialValue);
-
-  const rawValue = useSyncExternalStore(
-    (onStoreChange) => {
-      const keyListeners = getListeners(key);
-      keyListeners.add(onStoreChange);
-
-      const handleStorage = (event: StorageEvent) => {
-        if (event.key === key) {
-          if (event.newValue === null) {
-            cache.delete(key);
-          } else {
-            cache.set(key, event.newValue);
-          }
-          notifyListeners(key);
-        }
-      };
-
-      window.addEventListener("storage", handleStorage);
-
-      return () => {
-        keyListeners.delete(onStoreChange);
-        if (keyListeners.size === 0) {
-          listeners.delete(key);
-        }
-        window.removeEventListener("storage", handleStorage);
-      };
-    },
-    () => {
-      const cached = cache.get(key);
-      if (cached !== undefined) {
-        return cached;
-      }
-      try {
-        const item = localStorage.getItem(key);
-        if (item !== null) {
-          cache.set(key, item);
-          return item;
-        }
-      } catch {
-        // localStorage unavailable
-      }
-      return serializedInitial;
-    },
-    () => serializedInitial,
-  );
-
-  const value: T = parseJSON(rawValue, initialValue);
-
-  function setValue(updater: T | ((prev: T) => T)) {
-    const currentRaw = cache.get(key);
-    const current: T =
-      currentRaw === undefined
-        ? initialValue
-        : parseJSON(currentRaw, initialValue);
-    const next = isFunction(updater) ? updater(current) : updater;
-    const serialized = JSON.stringify(next);
-    try {
-      localStorage.setItem(key, serialized);
-    } catch (error) {
-      console.warn(`Failed to set localStorage key "${key}":`, error);
-      return;
-    }
-    cache.set(key, serialized);
-    notifyListeners(key);
-  }
-
-  function removeValue() {
-    localStorage.removeItem(key);
-    cache.delete(key);
-    notifyListeners(key);
-  }
-
-  return [value, setValue, removeValue];
+/**
+ * LocalStorage フック。`useWebStorage` に `localStorageStore` を束縛したラッパー。
+ *
+ * 他タブの変更も `storage` イベント経由で反映される。ストレージ未設定・取得失敗・SSR 時は
+ * `null` を返す。
+ *
+ * @param key - ストレージキー。
+ * @returns `useWebStorage` と同じ 3 要素タプル。
+ */
+export function useLocalStorage(key: string) {
+  return useWebStorage(localStorageStore, key);
 }

--- a/src/hooks/useSessionStorage/index.ts
+++ b/src/hooks/useSessionStorage/index.ts
@@ -1,0 +1,1 @@
+export { useSessionStorage } from "./useSessionStorage";

--- a/src/hooks/useSessionStorage/useSessionStorage.stories.tsx
+++ b/src/hooks/useSessionStorage/useSessionStorage.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useId, useRef } from "react";
 import { expect, userEvent } from "storybook/test";
-import { useLocalStorage } from "./useLocalStorage";
+import { useSessionStorage } from "./useSessionStorage";
 import { Button } from "../../components/Button";
 import { Input } from "../../components/Input";
 
-function UseLocalStorageDemo() {
-  const [value, setValue, removeValue] = useLocalStorage("storybook-demo");
+function UseSessionStorageDemo() {
+  const [value, setValue, removeValue] = useSessionStorage("storybook-demo");
   const inputRef = useRef<HTMLInputElement>(null);
   const valueId = useId();
   const inputId = useId();
@@ -43,7 +43,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  render: () => <UseLocalStorageDemo />,
+  render: () => <UseSessionStorageDemo />,
 } satisfies Meta;
 
 export default meta;
@@ -52,7 +52,7 @@ type Story = StoryObj;
 export const Default: Story = {
   play: async ({ canvas }) => {
     const [currentValue, newValueInput] = canvas.getAllByRole("textbox");
-    await expect(currentValue).toHaveValue("initial");
+    await expect(currentValue).toHaveValue("null");
 
     await userEvent.clear(newValueInput);
     await userEvent.type(newValueInput, "saved-value");
@@ -62,6 +62,6 @@ export const Default: Story = {
     await expect(currentValue).toHaveValue("saved-value");
 
     await userEvent.click(removeButton);
-    await expect(currentValue).toHaveValue("initial");
+    await expect(currentValue).toHaveValue("null");
   },
 };

--- a/src/hooks/useSessionStorage/useSessionStorage.test.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSessionStorage } from "./useSessionStorage";
+
+function createMockStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+function uniqueKey() {
+  return `test-key-${Math.random().toString(36).slice(2)}`;
+}
+
+describe(useSessionStorage, () => {
+  let sessionMock: ReturnType<typeof createMockStorage>;
+  let localMock: ReturnType<typeof createMockStorage>;
+
+  beforeEach(() => {
+    sessionMock = createMockStorage();
+    localMock = createMockStorage();
+    vi.stubGlobal("sessionStorage", sessionMock);
+    vi.stubGlobal("localStorage", localMock);
+  });
+
+  it("setValue は sessionStorage に書き込み localStorage には触らない", () => {
+    const key = uniqueKey();
+    const { result } = renderHook(() => useSessionStorage(key));
+
+    act(() => {
+      result.current[1]("stored");
+    });
+
+    expect(result.current[0]).toBe("stored");
+    expect(sessionMock.setItem).toHaveBeenCalledWith(key, "stored");
+    expect(localMock.setItem).not.toHaveBeenCalled();
+  });
+
+  it("sessionStorage の既存値を読み取る", () => {
+    const key = uniqueKey();
+    sessionMock.setItem(key, "stored");
+    const { result } = renderHook(() => useSessionStorage(key));
+    expect(result.current[0]).toBe("stored");
+  });
+
+  it("removeValue は sessionStorage のみから削除する", () => {
+    const key = uniqueKey();
+    const { result } = renderHook(() => useSessionStorage(key));
+
+    act(() => {
+      result.current[1]("stored");
+    });
+    act(() => {
+      result.current[2]();
+    });
+
+    expect(result.current[0]).toBeNull();
+    expect(sessionMock.removeItem).toHaveBeenCalledWith(key);
+    expect(localMock.removeItem).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -1,0 +1,15 @@
+import { sessionStorageStore } from "../../utils/webStorageStore";
+import { useWebStorage } from "../useWebStorage";
+
+/**
+ * SessionStorage フック。`useWebStorage` に `sessionStorageStore` を束縛したラッパー。
+ *
+ * SessionStorage は同一タブに閉じる Web Storage 仕様に従い、他タブとは同期しない。ストレージ
+ * 未設定・取得失敗・SSR 時は `null` を返す。
+ *
+ * @param key - ストレージキー。
+ * @returns `useWebStorage` と同じ 3 要素タプル。
+ */
+export function useSessionStorage(key: string) {
+  return useWebStorage(sessionStorageStore, key);
+}

--- a/src/hooks/useWebStorage/index.ts
+++ b/src/hooks/useWebStorage/index.ts
@@ -1,0 +1,1 @@
+export { useWebStorage } from "./useWebStorage";

--- a/src/hooks/useWebStorage/useWebStorage.test.ts
+++ b/src/hooks/useWebStorage/useWebStorage.test.ts
@@ -1,0 +1,165 @@
+import type { WebStorageStore } from "../../utils/webStorageStore";
+import { act, renderHook } from "@testing-library/react";
+import { useWebStorage } from "./useWebStorage";
+
+/**
+ * テスト用のインメモリ `WebStorageStore`。`useWebStorage` が渡されたストアへ正しく委譲しているかを
+ * 確認するため、localStorage / sessionStorage を経由せず素の関数でストア契約を満たす。
+ * `__listeners` は購読解除の副作用をテストから直接観測するために公開する。
+ */
+type MockStore = WebStorageStore & { __listeners: Set<() => void> };
+
+function createMockStore(): MockStore {
+  let value: string | null = null;
+  const listeners = new Set<() => void>();
+  const notify = () => {
+    for (const l of listeners) {
+      l();
+    }
+  };
+  return {
+    __listeners: listeners,
+    read: vi.fn(() => value),
+    write: vi.fn((_key: string, v: string) => {
+      value = v;
+      notify();
+      return true;
+    }),
+    remove: vi.fn(() => {
+      value = null;
+      notify();
+      return true;
+    }),
+    clear: vi.fn(() => {
+      value = null;
+      notify();
+      return true;
+    }),
+    subscribe: vi.fn((_key: string, l: () => void) => {
+      listeners.add(l);
+      return vi.fn(() => {
+        listeners.delete(l);
+      });
+    }),
+  };
+}
+
+function uniqueKey() {
+  return `test-key-${Math.random().toString(36).slice(2)}`;
+}
+
+describe(useWebStorage, () => {
+  it("ストア未設定なら null を返す", () => {
+    const store = createMockStore();
+    const { result } = renderHook(() => useWebStorage(store, uniqueKey()));
+    expect(result.current[0]).toBeNull();
+  });
+
+  it("渡されたストアの read で既存値を取得する", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    store.write(key, "stored");
+    const { result } = renderHook(() => useWebStorage(store, key));
+    expect(result.current[0]).toBe("stored");
+    expect(store.read).toHaveBeenCalledWith(key);
+  });
+
+  it("setValue は渡されたストアの write に委譲する", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { result } = renderHook(() => useWebStorage(store, key));
+
+    act(() => {
+      result.current[1]("updated");
+    });
+
+    expect(store.write).toHaveBeenCalledWith(key, "updated");
+    expect(result.current[0]).toBe("updated");
+  });
+
+  it("removeValue は渡されたストアの remove に委譲する", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { result } = renderHook(() => useWebStorage(store, key));
+
+    act(() => {
+      result.current[1]("stored");
+    });
+    act(() => {
+      result.current[2]();
+    });
+
+    expect(store.remove).toHaveBeenCalledWith(key);
+    expect(result.current[0]).toBeNull();
+  });
+
+  it("ストアの subscribe 経由で外部変更を受信して再レンダーする", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { result } = renderHook(() => useWebStorage(store, key));
+
+    expect(store.subscribe).toHaveBeenCalledWith(key, expect.any(Function));
+
+    act(() => {
+      store.write(key, "external");
+    });
+
+    expect(result.current[0]).toBe("external");
+  });
+
+  it("関数型更新はストアの最新値に基づいて解決される", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { result } = renderHook(() => useWebStorage(store, key));
+
+    act(() => {
+      result.current[1]((prev) => `${prev ?? ""}a`);
+    });
+    act(() => {
+      result.current[1]((prev) => `${prev ?? ""}b`);
+    });
+
+    expect(result.current[0]).toBe("ab");
+    expect(store.write).toHaveBeenLastCalledWith(key, "ab");
+  });
+
+  it("関数型更新の prev は外部書き込み後のストア最新値を見る", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { result } = renderHook(() => useWebStorage(store, key));
+
+    act(() => {
+      store.write(key, "base");
+      result.current[1]((prev) => `${prev ?? ""}+1`);
+    });
+
+    expect(result.current[0]).toBe("base+1");
+  });
+
+  it("再レンダーで subscribe が重複呼び出しされない", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { rerender } = renderHook(() => useWebStorage(store, key));
+
+    const initialCalls = vi.mocked(store.subscribe).mock.calls.length;
+    rerender();
+    rerender();
+
+    expect(vi.mocked(store.subscribe).mock.calls.length).toBe(initialCalls);
+  });
+
+  it("アンマウント時に購読が解除される", () => {
+    const store = createMockStore();
+    const key = uniqueKey();
+    const { unmount } = renderHook(() => useWebStorage(store, key));
+
+    expect(store.__listeners.size).toBe(1);
+    const unsubscribe = vi.mocked(store.subscribe).mock.results[0]
+      ?.value as ReturnType<typeof vi.fn>;
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(store.__listeners.size).toBe(0);
+  });
+});

--- a/src/hooks/useWebStorage/useWebStorage.ts
+++ b/src/hooks/useWebStorage/useWebStorage.ts
@@ -1,0 +1,48 @@
+import type { WebStorageStore } from "../../utils/webStorageStore";
+import { useSyncExternalStore } from "react";
+import { isFunction } from "../../utils/isFunction";
+
+/**
+ * Web Storage（localStorage / sessionStorage）を React 状態に同期させる汎用フック。
+ *
+ * 渡されたストアに読み書き・購読を委譲するため、同一タブの複数インスタンス間で値が自動同期する
+ * （localStorage ストアの場合は他タブの `storage` イベントにも反応する）。値は文字列のまま扱い、
+ * 構造化データを保存したい場合は呼び出し側でシリアライズ/デシリアライズする。
+ *
+ * ストレージが未設定・取得失敗・SSR のいずれの場合も `null` を返す（Web Storage ネイティブの
+ * `getItem` と揃える）。
+ *
+ * 通常は `useLocalStorage` / `useSessionStorage` を使い、カスタムストアを挿したいときのみ直接呼ぶ。
+ *
+ * @param store - 読み書きと購読を担う {@link WebStorageStore}。
+ * @param key - ストレージキー。
+ * @returns 3 要素タプル:
+ *
+ *   - `value`: 現在の値。未設定・取得失敗・SSR 時は `null`。
+ *   - `setValue`: 値を書き込む。`React.useState` と同様に関数型更新も可能で、`prev` にはストアの
+ *     最新値が渡される。戻り値はストアへの書き込み成否（`QuotaExceededError` 等で失敗時は `false`）。
+ *   - `removeValue`: 値を削除する。戻り値はストアでの削除成否。
+ */
+export function useWebStorage(
+  store: WebStorageStore,
+  key: string,
+): [
+  value: string | null,
+  setValue: (value: string | ((prev: string | null) => string)) => boolean,
+  removeValue: () => boolean,
+] {
+  const value = useSyncExternalStore(
+    (onStoreChange) => store.subscribe(key, onStoreChange),
+    () => store.read(key),
+    () => null,
+  );
+
+  const setValue = (updater: string | ((prev: string | null) => string)) => {
+    const next = isFunction(updater) ? updater(store.read(key)) : updater;
+    return store.write(key, next);
+  };
+
+  const removeValue = () => store.remove(key);
+
+  return [value, setValue, removeValue];
+}

--- a/src/utils/isFunction/index.ts
+++ b/src/utils/isFunction/index.ts
@@ -1,0 +1,1 @@
+export { isFunction } from "./isFunction";

--- a/src/utils/isFunction/isFunction.test.ts
+++ b/src/utils/isFunction/isFunction.test.ts
@@ -1,0 +1,41 @@
+import { isFunction } from "./isFunction";
+
+function noop() {}
+
+function returnX() {
+  return "x";
+}
+
+describe(isFunction, () => {
+  describe("関数の場合", () => {
+    it.for([
+      { label: "function declaration", input: noop },
+      { label: "built-in function", input: Math.max },
+    ])("$label → true", ({ input }) => {
+      expect(isFunction(input)).toBe(true);
+    });
+  });
+
+  describe("関数でない場合", () => {
+    it.for([
+      { label: "string", input: "x" },
+      { label: "number", input: 42 },
+      { label: "boolean", input: true },
+      { label: "null", input: null },
+      { label: "undefined", input: undefined },
+      { label: "object", input: {} },
+      { label: "array", input: [] },
+    ])("$label → false", ({ input }) => {
+      expect(isFunction(input)).toBe(false);
+    });
+  });
+
+  it("ユニオン型を関数成分で narrow する", () => {
+    const union: string | (() => string) = returnX;
+    if (isFunction(union)) {
+      expect(union()).toBe("x");
+    } else {
+      expect.unreachable();
+    }
+  });
+});

--- a/src/utils/isFunction/isFunction.ts
+++ b/src/utils/isFunction/isFunction.ts
@@ -1,0 +1,14 @@
+type AnyFunction = (...args: never[]) => unknown;
+
+/**
+ * 値が関数かを判定する型述語。ユニオン型 `T` のうち関数成分のみを narrow するので、
+ * `T` が `value | (() => value)` のようなフォームでも `if` ブランチで関数、`else` ブランチで
+ * 非関数側に narrow される。
+ *
+ * @template T - 判定対象の型。
+ * @param value - 判定対象の値。
+ * @returns `value` が関数なら `true`。
+ */
+export function isFunction<T>(value: T): value is Extract<T, AnyFunction> {
+  return typeof value === "function";
+}

--- a/src/utils/webStorageStore/index.ts
+++ b/src/utils/webStorageStore/index.ts
@@ -1,0 +1,2 @@
+export { localStorageStore, sessionStorageStore } from "./webStorageStore";
+export type { WebStorageStore } from "./webStorageStore";

--- a/src/utils/webStorageStore/webStorageStore.test.ts
+++ b/src/utils/webStorageStore/webStorageStore.test.ts
@@ -1,0 +1,523 @@
+import { localStorageStore, sessionStorageStore } from "./webStorageStore";
+
+function uniqueKey() {
+  return `test-${Math.random().toString(36).slice(2)}`;
+}
+
+/** 実ブラウザ同様 `storageArea` を必ず設定したうえで `storage` イベントを発火する。 */
+function dispatchLocalStorageEvent(
+  init: Omit<StorageEventInit, "storageArea">,
+) {
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      storageArea: window.localStorage,
+      ...init,
+    }),
+  );
+}
+
+function silenceWarn() {
+  return vi.spyOn(console, "warn").mockImplementation(() => {});
+}
+
+function silenceError() {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+describe("webStorageStore", () => {
+  describe.for([
+    {
+      name: "localStorageStore",
+      store: localStorageStore,
+      storageKey: "localStorage" as const,
+    },
+    {
+      name: "sessionStorageStore",
+      store: sessionStorageStore,
+      storageKey: "sessionStorage" as const,
+    },
+  ])("$name", ({ store, storageKey }) => {
+    const { read, write, remove, clear, subscribe } = store;
+
+    beforeEach(() => {
+      window[storageKey].clear();
+    });
+
+    describe(read, () => {
+      it("未設定のキーはnullを返す", () => {
+        expect(read(uniqueKey())).toBeNull();
+      });
+
+      it("ストレージが例外を投げてもnullを返す", () => {
+        vi.stubGlobal(storageKey, {
+          getItem: () => {
+            throw new Error("unavailable");
+          },
+        });
+        expect(read(uniqueKey())).toBeNull();
+      });
+    });
+
+    describe(write, () => {
+      it("書き込んだ値がreadで取得できる", () => {
+        const key = uniqueKey();
+        write(key, "hello");
+        expect(read(key)).toBe("hello");
+      });
+
+      it("成功時にtrueを返す", () => {
+        expect(write(uniqueKey(), "hello")).toBe(true);
+      });
+
+      it("QuotaExceededError時にfalseを返しwarnを出す", () => {
+        const warnSpy = silenceWarn();
+        vi.stubGlobal(storageKey, {
+          setItem: () => {
+            throw new DOMException("quota", "QuotaExceededError");
+          },
+        });
+        expect(write(uniqueKey(), "hello")).toBe(false);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it("失敗時は購読者に通知しない", () => {
+        silenceWarn();
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+        vi.stubGlobal(storageKey, {
+          setItem: () => {
+            throw new DOMException("quota", "QuotaExceededError");
+          },
+        });
+
+        write(key, "x");
+
+        expect(listener).not.toHaveBeenCalled();
+        unsubscribe();
+      });
+    });
+
+    describe(remove, () => {
+      it("書き込んだ値を削除する", () => {
+        const key = uniqueKey();
+        write(key, "hello");
+        remove(key);
+        expect(read(key)).toBeNull();
+      });
+
+      it("成功時にtrueを返す", () => {
+        expect(remove(uniqueKey())).toBe(true);
+      });
+
+      it("ストレージが例外を投げた時にfalseを返す", () => {
+        silenceWarn();
+        vi.stubGlobal(storageKey, {
+          removeItem: () => {
+            throw new Error("unavailable");
+          },
+        });
+        expect(remove(uniqueKey())).toBe(false);
+      });
+
+      it("失敗時は購読者に通知しない", () => {
+        silenceWarn();
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+        vi.stubGlobal(storageKey, {
+          removeItem: () => {
+            throw new Error("unavailable");
+          },
+        });
+
+        remove(key);
+
+        expect(listener).not.toHaveBeenCalled();
+        unsubscribe();
+      });
+    });
+
+    describe(clear, () => {
+      it("全キーを削除する", () => {
+        const k1 = uniqueKey();
+        const k2 = uniqueKey();
+        write(k1, "a");
+        write(k2, "b");
+
+        clear();
+
+        expect(read(k1)).toBeNull();
+        expect(read(k2)).toBeNull();
+      });
+
+      it("全購読者へ通知する", () => {
+        const k1 = uniqueKey();
+        const k2 = uniqueKey();
+        const l1 = vi.fn();
+        const l2 = vi.fn();
+        const u1 = subscribe(k1, l1);
+        const u2 = subscribe(k2, l2);
+
+        clear();
+
+        expect(l1).toHaveBeenCalledTimes(1);
+        expect(l2).toHaveBeenCalledTimes(1);
+        u1();
+        u2();
+      });
+
+      it("成功時にtrueを返す", () => {
+        expect(clear()).toBe(true);
+      });
+
+      it("ストレージが例外を投げた時にfalseを返し通知をスキップする", () => {
+        silenceWarn();
+        vi.stubGlobal(storageKey, {
+          clear: () => {
+            throw new DOMException("security", "SecurityError");
+          },
+        });
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+
+        expect(clear()).toBe(false);
+        expect(listener).not.toHaveBeenCalled();
+
+        unsubscribe();
+      });
+    });
+
+    describe(subscribe, () => {
+      it("同じキーへのwriteでリスナーが呼ばれる", () => {
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+
+        write(key, "hello");
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        unsubscribe();
+      });
+
+      it("同じキーへのremoveでリスナーが呼ばれる", () => {
+        const key = uniqueKey();
+        write(key, "hello");
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+
+        remove(key);
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        unsubscribe();
+      });
+
+      it("unsubscribe後はリスナーが呼ばれない", () => {
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+
+        unsubscribe();
+        write(key, "hello");
+
+        expect(listener).not.toHaveBeenCalled();
+      });
+
+      it("異なるキーへのwriteでリスナーが呼ばれない", () => {
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const unsubscribe = subscribe(key, listener);
+
+        write(uniqueKey(), "hello");
+
+        expect(listener).not.toHaveBeenCalled();
+        unsubscribe();
+      });
+
+      it("あるリスナーがthrowしても他のリスナーは呼ばれる", () => {
+        silenceError();
+        const key = uniqueKey();
+        const bad = vi.fn(() => {
+          throw new Error("boom");
+        });
+        const good = vi.fn();
+        const u1 = subscribe(key, bad);
+        const u2 = subscribe(key, good);
+
+        write(key, "x");
+
+        expect(bad).toHaveBeenCalledTimes(1);
+        expect(good).toHaveBeenCalledTimes(1);
+        u1();
+        u2();
+      });
+
+      it("clearでもthrowしたリスナーが他をブロックしない", () => {
+        silenceError();
+        const k1 = uniqueKey();
+        const k2 = uniqueKey();
+        const bad = vi.fn(() => {
+          throw new Error("boom");
+        });
+        const good = vi.fn();
+        const u1 = subscribe(k1, bad);
+        const u2 = subscribe(k2, good);
+
+        clear();
+
+        expect(bad).toHaveBeenCalledTimes(1);
+        expect(good).toHaveBeenCalledTimes(1);
+        u1();
+        u2();
+      });
+
+      it("同一リスナーを重複subscribeしてもwriteで一度しか呼ばれない", () => {
+        const key = uniqueKey();
+        const listener = vi.fn();
+        const u1 = subscribe(key, listener);
+        const u2 = subscribe(key, listener);
+
+        write(key, "x");
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        u1();
+        u2();
+      });
+
+      it("リスナー内で同キーにsubscribeしても今回のnotifyでは呼ばれない", () => {
+        const key = uniqueKey();
+        const lateListener = vi.fn();
+        let lateUnsubscribe: (() => void) | undefined;
+        const firstListener = vi.fn(() => {
+          lateUnsubscribe = subscribe(key, lateListener);
+        });
+        const u1 = subscribe(key, firstListener);
+
+        write(key, "x");
+
+        expect(firstListener).toHaveBeenCalledTimes(1);
+        expect(lateListener).not.toHaveBeenCalled();
+        u1();
+        lateUnsubscribe?.();
+      });
+
+      it("リスナー内で他のリスナーをunsubscribeしても他のリスナーは呼ばれる", () => {
+        const key = uniqueKey();
+        const l2 = vi.fn();
+        // l1 を先に subscribe しつつ l1 から l2 の unsubscribe (u2) を呼ぶため、
+        // 参照を箱渡しして const を維持する。
+        const ref: { u2?: () => void } = {};
+        const l1 = vi.fn(() => {
+          ref.u2?.();
+        });
+        const u1 = subscribe(key, l1);
+        const u2 = subscribe(key, l2);
+        ref.u2 = u2;
+
+        write(key, "x");
+
+        expect(l1).toHaveBeenCalledTimes(1);
+        expect(l2).toHaveBeenCalledTimes(1);
+        u1();
+        u2();
+      });
+
+      it("unsubscribeを複数回呼んでも後続のsubscribeが壊れない", () => {
+        const key = uniqueKey();
+        const l1 = vi.fn();
+        const l2 = vi.fn();
+        const u1 = subscribe(key, l1);
+        u1();
+        const u2 = subscribe(key, l2);
+        u1();
+
+        write(key, "x");
+
+        expect(l1).not.toHaveBeenCalled();
+        expect(l2).toHaveBeenCalledTimes(1);
+        u2();
+      });
+    });
+  });
+
+  describe("localStorageStore 他タブ連携", () => {
+    const { subscribe } = localStorageStore;
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("同じキーのstorageイベントでリスナーが呼ばれる", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const unsubscribe = subscribe(key, listener);
+
+      dispatchLocalStorageEvent({ key, newValue: "from-other-tab" });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsubscribe();
+    });
+
+    it("異なるキーのstorageイベントでは呼ばれない", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const unsubscribe = subscribe(key, listener);
+
+      dispatchLocalStorageEvent({ key: "other-key", newValue: "x" });
+
+      expect(listener).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("他タブのclearに伴うstorageイベント（key=null）でリスナーが呼ばれる", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const unsubscribe = subscribe(key, listener);
+
+      dispatchLocalStorageEvent({ key: null, newValue: null });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsubscribe();
+    });
+
+    it("同一リスナーを重複subscribeしてもstorageイベントで一度しか呼ばれない", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const u1 = subscribe(key, listener);
+      const u2 = subscribe(key, listener);
+
+      dispatchLocalStorageEvent({ key, newValue: "x" });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      u1();
+      u2();
+    });
+
+    it("unsubscribeでstorageイベントの購読も解除される", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const unsubscribe = subscribe(key, listener);
+      unsubscribe();
+
+      dispatchLocalStorageEvent({ key, newValue: "x" });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("storageAreaがsessionStorageのイベントは無視する", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const unsubscribe = subscribe(key, listener);
+
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key,
+          newValue: "x",
+          storageArea: window.sessionStorage,
+        }),
+      );
+
+      expect(listener).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+  });
+
+  describe("sessionStorageStore 単一タブ", () => {
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
+    it("他タブ由来のstorageイベントには反応しない", () => {
+      const key = uniqueKey();
+      const listener = vi.fn();
+      const unsubscribe = sessionStorageStore.subscribe(key, listener);
+
+      window.dispatchEvent(new StorageEvent("storage", { key, newValue: "x" }));
+
+      expect(listener).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+  });
+
+  describe("ストア間の独立性", () => {
+    beforeEach(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    it("localStorageStore.writeはsessionStorageStoreの購読者に通知しない", () => {
+      const key = uniqueKey();
+      const sessionListener = vi.fn();
+      const unsubscribe = sessionStorageStore.subscribe(key, sessionListener);
+
+      localStorageStore.write(key, "x");
+
+      expect(sessionListener).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("sessionStorageStore.writeはlocalStorageStoreの購読者に通知しない", () => {
+      const key = uniqueKey();
+      const localListener = vi.fn();
+      const unsubscribe = localStorageStore.subscribe(key, localListener);
+
+      sessionStorageStore.write(key, "x");
+
+      expect(localListener).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("同じキーでも両ストアは独立した値を保持する", () => {
+      const key = uniqueKey();
+      localStorageStore.write(key, "local-value");
+      sessionStorageStore.write(key, "session-value");
+
+      expect(localStorageStore.read(key)).toBe("local-value");
+      expect(sessionStorageStore.read(key)).toBe("session-value");
+    });
+
+    it("localStorageStore.clearはsessionStorageStoreに影響しない", () => {
+      const key = uniqueKey();
+      sessionStorageStore.write(key, "keep");
+
+      localStorageStore.clear();
+
+      expect(sessionStorageStore.read(key)).toBe("keep");
+    });
+
+    it("sessionStorageStore.clearはlocalStorageStoreに影響しない", () => {
+      const key = uniqueKey();
+      localStorageStore.write(key, "keep");
+
+      sessionStorageStore.clear();
+
+      expect(localStorageStore.read(key)).toBe("keep");
+    });
+  });
+
+  describe("複数購読者", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it("同じキーの複数リスナーが全員呼ばれる", () => {
+      const key = uniqueKey();
+      const l1 = vi.fn();
+      const l2 = vi.fn();
+      const l3 = vi.fn();
+      const u1 = localStorageStore.subscribe(key, l1);
+      const u2 = localStorageStore.subscribe(key, l2);
+      const u3 = localStorageStore.subscribe(key, l3);
+
+      localStorageStore.write(key, "x");
+
+      expect(l1).toHaveBeenCalledTimes(1);
+      expect(l2).toHaveBeenCalledTimes(1);
+      expect(l3).toHaveBeenCalledTimes(1);
+      u1();
+      u2();
+      u3();
+    });
+  });
+});

--- a/src/utils/webStorageStore/webStorageStore.ts
+++ b/src/utils/webStorageStore/webStorageStore.ts
@@ -1,0 +1,270 @@
+/**
+ * Web Storage API（localStorage / sessionStorage）に対する薄いラッパーと、同タブ内購読機構。
+ *
+ * ネイティブの `storage` イベントは他タブからしか発火しないため、同一タブ内で行われた
+ * `write` / `remove` / `clear` を購読者へ届ける経路として、キー単位の購読者 Set を自前で保持する。
+ */
+
+/**
+ * Web Storage への読み書きと変更購読を束ねたストア。
+ * `localStorageStore` / `sessionStorageStore` が実装する共通インターフェース。
+ */
+export interface WebStorageStore {
+  /** 指定キーの値を読む。未設定または取得不可（SSR／プライベートブラウジング等）時は `null`。 */
+  read: (key: string) => string | null;
+  /** 指定キーに値を書き、購読者へ通知する。失敗時は `false` を返し通知はスキップする。 */
+  write: (key: string, value: string) => boolean;
+  /** 指定キーを削除し、購読者へ通知する。失敗時は `false` を返し通知はスキップする。 */
+  remove: (key: string) => boolean;
+  /** 全キーを削除し、全購読者へ通知する。失敗時は `false` を返し通知はスキップする。 */
+  clear: () => boolean;
+  /** 指定キーの変更を購読する。戻り値を呼ぶと解除される（複数回呼んでも冪等）。 */
+  subscribe: (key: string, listener: () => void) => () => void;
+}
+
+/**
+ * ストアの種類を表す discriminator。
+ * - `"localStorage"` → `window.localStorage`（他タブの `storage` イベントで同期）
+ * - `"sessionStorage"` → `window.sessionStorage`（同一タブに閉じるため cross-tab 同期は不要）
+ */
+type StorageType = "localStorage" | "sessionStorage";
+
+/** 何もしない関数。session store の storage listener セットアップとして使う。 */
+function noop(): void {
+  // 意図的な no-op
+}
+
+/**
+ * `storageType` に応じた Web Storage ストアを生成するファクトリ。
+ *
+ * `listeners` Map はこのクロージャ内に閉じ込めるため、local/session 間でキー名が衝突しても
+ * 互いに干渉しない（ストア間の独立性はテストで担保）。
+ *
+ * @param storageType - 使用するストレージ種別（{@link StorageType}）
+ */
+function createStore(storageType: StorageType): WebStorageStore {
+  const isLocalStorage = storageType === "localStorage";
+
+  /**
+   * ストレージを遅延取得する。毎回 `window` から引くことで、`vi.stubGlobal` 等による
+   * テスト時の差し替えにも追随する。
+   */
+  const getStorage = (): Storage =>
+    isLocalStorage ? window.localStorage : window.sessionStorage;
+  /** キー → そのキーを購読しているリスナー集合。 */
+  const listeners = new Map<string, Set<() => void>>();
+
+  /** 指定キーの購読者 Set を取得する。未作成なら空の Set を作って登録し、以降は同じ参照を返す。 */
+  function getListeners(key: string): Set<() => void> {
+    const existing = listeners.get(key);
+    if (existing) {
+      return existing;
+    }
+    const created = new Set<() => void>();
+    listeners.set(key, created);
+    return created;
+  }
+
+  /**
+   * リスナーを 1 件呼び出す。例外が出ても他のリスナーをブロックしないよう握りつぶし、
+   * `console.error` に記録する（React 経由では通常 throw しないが防御用）。
+   */
+  function invoke(listener: () => void): void {
+    try {
+      listener();
+    } catch (error) {
+      console.error(`${storageType} listener threw:`, error);
+    }
+  }
+
+  /**
+   * 指定キーの全購読者を同期的に呼ぶ。未登録キーに対しては何もしない
+   * （`getListeners` と違い、空の Set を作らないのでレジストリに残滓が残らない）。
+   *
+   * リスナー内で同キーの `subscribe` / `unsubscribe` や再入的な `write` が起こる可能性があるため、
+   * イテレーション前にスナップショットを取って Set 変更の影響を受けないようにする。
+   */
+  function notify(key: string): void {
+    const keyListeners = listeners.get(key);
+    if (!keyListeners) {
+      return;
+    }
+    const snapshot = [...keyListeners];
+    for (const listener of snapshot) {
+      invoke(listener);
+    }
+  }
+
+  /**
+   * 登録中の全キーの全購読者を同期的に呼ぶ。
+   * 自タブの `clear` および他タブの `clear` に伴う `storage` イベント（key=null）の伝搬に使う。
+   *
+   * `notify` と同じ理由でスナップショットを取ってからイテレートする。
+   */
+  function notifyAll(): void {
+    const snapshot: Array<() => void> = [];
+    for (const keyListeners of listeners.values()) {
+      for (const listener of keyListeners) {
+        snapshot.push(listener);
+      }
+    }
+    for (const listener of snapshot) {
+      invoke(listener);
+    }
+  }
+
+  /**
+   * 指定キーの生文字列を返す。未設定またはストレージ利用不可（SSR／プライベートブラウジング等）な
+   * 場合は `null` を返し、例外は外へ伝搬させない。
+   *
+   * @param key - 読み取るキー
+   * @returns 保存されている文字列。未設定または取得失敗時は `null`
+   */
+  function read(key: string): string | null {
+    try {
+      return getStorage().getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 指定キーに生文字列を書き込み、同一タブの購読者へ通知する。
+   * `QuotaExceededError` などで失敗した場合は warn を出して `false` を返し、通知はスキップする
+   * （保存されていない値で購読者を起こさないため）。
+   *
+   * @param key - 書き込むキー
+   * @param value - 書き込む文字列
+   * @returns 書き込みに成功したら `true`、失敗なら `false`
+   */
+  function write(key: string, value: string): boolean {
+    try {
+      getStorage().setItem(key, value);
+    } catch (error) {
+      console.warn(`Failed to set ${storageType} key "${key}":`, error);
+      return false;
+    }
+    notify(key);
+    return true;
+  }
+
+  /**
+   * 指定キーを削除し、同一タブの購読者へ通知する。
+   * 失敗した場合は warn を出して `false` を返し、通知はスキップする。
+   *
+   * @param key - 削除するキー
+   * @returns 削除に成功したら `true`、失敗なら `false`
+   */
+  function remove(key: string): boolean {
+    try {
+      getStorage().removeItem(key);
+    } catch (error) {
+      console.warn(`Failed to remove ${storageType} key "${key}":`, error);
+      return false;
+    }
+    notify(key);
+    return true;
+  }
+
+  /**
+   * ストレージ全体をクリアし、登録中の全購読者へ通知する。
+   * `window.localStorage.clear()` を直接呼ぶと同タブには通知が届かないため、アプリ側では
+   * 必ずこちらを経由する。失敗した場合は warn を出して `false` を返し、通知はスキップする。
+   *
+   * @returns クリアに成功したら `true`、失敗なら `false`
+   */
+  function clear(): boolean {
+    try {
+      getStorage().clear();
+    } catch (error) {
+      console.warn(`Failed to clear ${storageType}:`, error);
+      return false;
+    }
+    notifyAll();
+    return true;
+  }
+
+  /**
+   * 他タブ由来の `storage` イベントを `listeners` レジストリへディスパッチする
+   * window リスナーを 1 回だけ設置するためのセットアップ関数を返す。
+   * クロージャに `installed` フラグを持ち、何度呼んでも window リスナーが重複しないようにする。
+   */
+  function createLocalStorageListenerSetup(): () => void {
+    let installed = false;
+    return () => {
+      if (installed || typeof window === "undefined") {
+        return;
+      }
+      window.addEventListener("storage", (event) => {
+        // ブラウザ由来の storage イベントでは `storageArea` が必ず設定される。
+        // 異なる Storage（sessionStorage 等）由来のイベントは弾く。
+        if (event.storageArea !== getStorage()) {
+          return;
+        }
+        if (event.key === null) {
+          // 他タブの `clear()` は key=null で飛んでくる
+          notifyAll();
+          return;
+        }
+        notify(event.key);
+      });
+      installed = true;
+    };
+  }
+
+  /**
+   * `storage` イベントの購読セットアップ関数。
+   * - localStorage: 初回 subscribe 時に window リスナーを 1 度だけ install する
+   * - sessionStorage: 同一タブで完結するため何もしない（cross-tab 同期が無い）
+   *
+   * ファクトリ時点で関数自体を分岐させることで、呼び出し側は `isLocal` を気にしない。
+   */
+  const ensureStorageListener: () => void = isLocalStorage
+    ? createLocalStorageListenerSetup()
+    : noop;
+
+  /**
+   * 指定キーの変更を購読する。同一タブの `write` / `remove` / `clear` と、他タブで発火する
+   * `storage` イベント（localStorage のみ）の両方でリスナーが同期的に呼ばれる。
+   *
+   * 戻り値の解除関数は複数回呼び出しても安全（冪等）で、後から別の `subscribe` が Map 上に
+   * 作り直した Set を誤って削除しないよう、解除時に自身の Set であることを確認してから除去する。
+   *
+   * @param key - 購読対象のキー
+   * @param listener - 変更通知で同期的に呼ばれるコールバック
+   * @returns 購読解除関数
+   */
+  function subscribe(key: string, listener: () => void): () => void {
+    ensureStorageListener();
+    const keyListeners = getListeners(key);
+    keyListeners.add(listener);
+
+    let unsubscribed = false;
+    return () => {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+      keyListeners.delete(listener);
+      // 別の subscribe が Map の Set を差し替えている可能性があるため、自分の Set に限って削除する
+      if (keyListeners.size === 0 && listeners.get(key) === keyListeners) {
+        listeners.delete(key);
+      }
+    };
+  }
+
+  return { read, write, remove, clear, subscribe };
+}
+
+/**
+ * `window.localStorage` を対象とするストア。
+ * 他タブの変更も `storage` イベント経由で購読者へ届く。
+ */
+export const localStorageStore: WebStorageStore = createStore("localStorage");
+
+/**
+ * `window.sessionStorage` を対象とするストア。
+ * 同一タブに閉じる Web Storage 仕様に従い、他タブとの同期は行わない。
+ */
+export const sessionStorageStore: WebStorageStore =
+  createStore("sessionStorage");


### PR DESCRIPTION
## Summary

- `useSessionStorage` 新設と、`useLocalStorage` / `useSessionStorage` が共有する `useWebStorage` コアの切り出し
- `src/utils/webStorageStore` 追加（localStorage / sessionStorage 両対応の薄ラッパー + 同タブ pub/sub + 他タブ `storage` イベント連携）
- API を Web Storage ネイティブと揃え、**string 前提 / null sentinel**（未設定・取得失敗・SSR は全て `null`）で簡素化
- 汎用型述語 `isFunction` を `src/utils/isFunction` へ配置（`Extract<T, AnyFunction>` でユニオン narrow 対応）
- `oxlint.config.ts`: `jsdoc/require-returns-type` を off（TS シグネチャと重複するため `ts(80004)` 抑制目的）

## Test plan

- [ ] `pnpm test` で `useWebStorage` / `useLocalStorage` / `useSessionStorage` / `webStorageStore` / `isFunction` のテストが全て通ることを確認
- [ ] `pnpm check` (lint / fmt / knip) がクリーンなことを確認
- [ ] Storybook で `useLocalStorage` / `useSessionStorage` それぞれの Demo を起動し、Save / Remove の挙動と InteractionTest 通過を確認
- [ ] 同一タブ内で複数インスタンスが同期すること、localStorage 版は別タブの変更も反映されること、sessionStorage 版はタブ間で分離されることをブラウザで目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)