### PR TITLE
refactor(hooks): extract composition store from useIsComposing

### DIFF
--- a/src/hooks/useIsComposing/useIsComposing.stories.tsx
+++ b/src/hooks/useIsComposing/useIsComposing.stories.tsx
@@ -1,29 +1,183 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { useId } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useIsComposing } from "./useIsComposing";
 import { Input } from "../../components/Input";
+
+interface LogEntry {
+  id: number;
+  label: string;
+  event: "compositionstart" | "compositionend";
+  accent: "capture" | "target" | "bubble";
+}
+
+const accentClass: Record<LogEntry["accent"], string> = {
+  capture: "text-primary",
+  target: "text-foreground",
+  bubble: "text-muted-foreground",
+};
+
+function StateCard({
+  label,
+  phase,
+  value,
+}: {
+  label: string;
+  phase: string;
+  value: boolean;
+}) {
+  return (
+    <div
+      className={`flex flex-col gap-1 rounded-md border p-3 transition-colors ${
+        value ? "border-primary bg-primary/10" : "border-border bg-background"
+      }`}
+    >
+      <span className="text-label-sm text-muted-foreground">{phase}</span>
+      <code className="text-label-md text-foreground">{label}</code>
+      <span
+        className={`font-mono text-body-md ${
+          value ? "text-primary" : "text-muted-foreground"
+        }`}
+      >
+        {String(value)}
+      </span>
+    </div>
+  );
+}
 
 const meta = {
   component: undefined,
   tags: ["!manifest"],
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { layout: "centered" },
   render: () => {
-    const isComposing = useIsComposing();
-    const id = useId();
+    const isComposingCapture = useIsComposing(true);
+    const isComposingBubble = useIsComposing(false);
+    const [log, setLog] = useState<LogEntry[]>([]);
+    const counterRef = useRef(0);
+    const inputId = useId();
+
+    useEffect(() => {
+      const append = (
+        label: string,
+        event: LogEntry["event"],
+        accent: LogEntry["accent"],
+      ) => {
+        counterRef.current += 1;
+        const id = counterRef.current;
+        setLog((prev) => [...prev, { id, label, event, accent }]);
+      };
+
+      const phases = [
+        { capture: true, accent: "capture", label: "📥 document (capture)" },
+        { capture: false, accent: "bubble", label: "📤 document (bubble)" },
+      ] as const;
+
+      const handlers = phases.flatMap(({ capture, accent, label }) =>
+        (["compositionstart", "compositionend"] as const).map((event) => ({
+          event,
+          capture,
+          listener: () => {
+            append(label, event, accent);
+          },
+        })),
+      );
+
+      for (const { event, listener, capture } of handlers) {
+        document.addEventListener(event, listener, capture);
+      }
+      return () => {
+        for (const { event, listener, capture } of handlers) {
+          document.removeEventListener(event, listener, capture);
+        }
+      };
+    }, []);
+
+    const appendTarget = (event: LogEntry["event"]) => {
+      counterRef.current += 1;
+      const id = counterRef.current;
+      setLog((prev) => [
+        ...prev,
+        { id, label: "🎯 input (target / React)", event, accent: "target" },
+      ]);
+    };
 
     return (
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-2">
-          <p>isComposing</p>
-          <p className="rounded border border-gray-800 px-1 py-0.5 text-sm">
-            {isComposing.toString()}
+      <div className="flex w-[520px] flex-col gap-5">
+        <div className="flex flex-col gap-1">
+          <p className="text-label-lg font-semibold text-foreground">
+            capture と bubble の発火順デモ
+          </p>
+          <p className="text-body-sm text-muted-foreground">
+            下の入力欄に日本語 IME で「かんじ」などと入力して変換すると、 同じ{" "}
+            <code>compositionstart</code> が capture → target → bubble の順で
+            記録されます。<code>useIsComposing(true)</code>{" "}
+            はこのうち最も早いタイミング、
+            <code>useIsComposing(false)</code>{" "}
+            は最も遅いタイミングで状態を切り替えます。
           </p>
         </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <StateCard
+            label="useIsComposing(true)"
+            phase="capture phase"
+            value={isComposingCapture}
+          />
+          <StateCard
+            label="useIsComposing(false)"
+            phase="bubble phase"
+            value={isComposingBubble}
+          />
+        </div>
+
         <div className="flex flex-col gap-2">
-          <label htmlFor={id}>your text</label>
-          <Input id={id} />
+          <label htmlFor={inputId} className="text-label-md text-foreground">
+            your text
+          </label>
+          <Input
+            id={inputId}
+            onCompositionStart={() => {
+              appendTarget("compositionstart");
+            }}
+            onCompositionEnd={() => {
+              appendTarget("compositionend");
+            }}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/40 p-3">
+          <div className="flex items-center justify-between">
+            <span className="text-label-md text-foreground">Event log</span>
+            <button
+              type="button"
+              className="text-label-sm text-muted-foreground underline"
+              onClick={() => {
+                counterRef.current = 0;
+                setLog([]);
+              }}
+            >
+              clear
+            </button>
+          </div>
+          {log.length === 0 ? (
+            <p className="text-body-sm text-muted-foreground">
+              まだイベントが記録されていません。
+            </p>
+          ) : (
+            <ol className="flex flex-col gap-1 font-mono text-body-sm">
+              {log.map((entry) => (
+                <li
+                  key={entry.id}
+                  className={`flex items-center gap-2 ${accentClass[entry.accent]}`}
+                >
+                  <span className="w-6 text-right text-muted-foreground tabular-nums">
+                    {entry.id}
+                  </span>
+                  <span className="min-w-[170px]">{entry.label}</span>
+                  <span>{entry.event}</span>
+                </li>
+              ))}
+            </ol>
+          )}
         </div>
       </div>
     );

--- a/src/hooks/useIsComposing/useIsComposing.test.ts
+++ b/src/hooks/useIsComposing/useIsComposing.test.ts
@@ -1,188 +1,253 @@
 import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import { useIsComposing } from "./useIsComposing";
 
 function dispatchComposition(type: "compositionstart" | "compositionend") {
   document.dispatchEvent(new CompositionEvent(type));
 }
 
+function countCaptureCompositionStart(
+  calls: Array<Parameters<typeof document.addEventListener>>,
+): number {
+  return calls.filter(
+    ([type, , options]) => type === "compositionstart" && options === true,
+  ).length;
+}
+
 describe(useIsComposing, () => {
-  it("初期値がfalseであること", () => {
-    const { result } = renderHook(() => useIsComposing());
-    expect(result.current).toBe(false);
+  describe("基本動作", () => {
+    it("compositionstart で true、compositionend で false に再レンダーされること", () => {
+      const { result } = renderHook(() => useIsComposing());
+      expect(result.current).toBe(false);
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(result.current).toBe(true);
+
+      act(() => {
+        dispatchComposition("compositionend");
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("同一コンポーネント内で capture と bubble の値を同時に取得できること", () => {
+      const { result } = renderHook(() => ({
+        capture: useIsComposing(true),
+        bubble: useIsComposing(false),
+      }));
+
+      expect(result.current).toEqual({ capture: false, bubble: false });
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(result.current).toEqual({ capture: true, bubble: true });
+
+      act(() => {
+        dispatchComposition("compositionend");
+      });
+      expect(result.current).toEqual({ capture: false, bubble: false });
+    });
   });
 
-  it("compositionstart でtrue、compositionend でfalseになること", () => {
-    const { result } = renderHook(() => useIsComposing());
+  describe("ストア選択", () => {
+    it.for([
+      { capture: true, phase: "キャプチャ" },
+      { capture: false, phase: "バブル" },
+    ])(
+      "capture=$capture で $phase フェーズのリスナーを登録すること",
+      ({ capture }) => {
+        const spy = vi.spyOn(document, "addEventListener");
 
-    act(() => {
-      dispatchComposition("compositionstart");
-    });
-    expect(result.current).toBe(true);
+        renderHook(() => useIsComposing(capture));
 
-    act(() => {
-      dispatchComposition("compositionend");
+        expect(spy).toHaveBeenCalledWith(
+          "compositionstart",
+          expect.any(Function),
+          capture,
+        );
+        expect(spy).toHaveBeenCalledWith(
+          "compositionend",
+          expect.any(Function),
+          capture,
+        );
+      },
+    );
+
+    it("capture が変更されたとき、新しいストアの値を返すこと", () => {
+      const { result, rerender } = renderHook(
+        ({ capture }) => useIsComposing(capture),
+        { initialProps: { capture: true as boolean } },
+      );
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(result.current).toBe(true);
+
+      // capture→bubble に切り替わると、capture ストアは最後の購読者が抜けて composing がリセットされ、
+      // 新たに購読する bubble ストアも初期値 false なので結果は false になる
+      rerender({ capture: false });
+      expect(result.current).toBe(false);
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(result.current).toBe(true);
+
+      act(() => {
+        dispatchComposition("compositionend");
+      });
+      expect(result.current).toBe(false);
     });
-    expect(result.current).toBe(false);
+
+    it("capture 変更時に旧フェーズのリスナーを除去し新フェーズのリスナーを登録すること", () => {
+      const addSpy = vi.spyOn(document, "addEventListener");
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+
+      const { rerender, unmount } = renderHook(
+        ({ capture }) => useIsComposing(capture),
+        { initialProps: { capture: true as boolean } },
+      );
+
+      addSpy.mockClear();
+      removeSpy.mockClear();
+
+      rerender({ capture: false });
+
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        true,
+      );
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionend",
+        expect.any(Function),
+        true,
+      );
+      expect(addSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        false,
+      );
+      expect(addSpy).toHaveBeenCalledWith(
+        "compositionend",
+        expect.any(Function),
+        false,
+      );
+
+      unmount();
+    });
   });
 
-  it("複数インスタンスが同じ状態を共有すること", () => {
-    const { result: result1 } = renderHook(() => useIsComposing());
-    const { result: result2 } = renderHook(() => useIsComposing());
+  describe("購読ライフサイクル", () => {
+    it("アンマウント時に document リスナーを除去し、以後のイベントに反応しないこと", () => {
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+      const { result, unmount } = renderHook(() => useIsComposing());
 
-    act(() => {
-      dispatchComposition("compositionstart");
-    });
-    expect(result1.current).toBe(true);
-    expect(result2.current).toBe(true);
+      unmount();
 
-    act(() => {
-      dispatchComposition("compositionend");
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        true,
+      );
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionend",
+        expect.any(Function),
+        true,
+      );
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(result.current).toBe(false);
     });
-    expect(result1.current).toBe(false);
-    expect(result2.current).toBe(false);
+
+    it("composing 中にアンマウントしても、再マウント後は false から始まること", () => {
+      // 購読切れ目で composing が false にリセットされる挙動のフック経由回帰テスト。
+      // 購読者不在中に compositionend を取りこぼしても、次回マウント時の初期値に
+      // 古い true を引きずらないことを保証する。
+      const { result: r1, unmount } = renderHook(() => useIsComposing());
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(r1.current).toBe(true);
+
+      unmount();
+
+      // 購読者がいない間の compositionend はストアに届かない
+      act(() => {
+        dispatchComposition("compositionend");
+      });
+
+      const { result: r2 } = renderHook(() => useIsComposing());
+      expect(r2.current).toBe(false);
+    });
+
+    it("StrictMode 下でも正しく動作しリスナーリークが起きないこと", () => {
+      const addSpy = vi.spyOn(document, "addEventListener");
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+
+      const { result, unmount } = renderHook(() => useIsComposing(), {
+        wrapper: StrictMode,
+      });
+
+      // mount→unmount→再mount を経ても capture リスナーは純増 1 の状態
+      expect(
+        countCaptureCompositionStart(addSpy.mock.calls) -
+          countCaptureCompositionStart(removeSpy.mock.calls),
+      ).toBe(1);
+
+      act(() => {
+        dispatchComposition("compositionstart");
+      });
+      expect(result.current).toBe(true);
+
+      act(() => {
+        dispatchComposition("compositionend");
+      });
+      expect(result.current).toBe(false);
+
+      unmount();
+
+      // unmount 後は純増 0 (リスナーリークなし)
+      expect(
+        countCaptureCompositionStart(addSpy.mock.calls) -
+          countCaptureCompositionStart(removeSpy.mock.calls),
+      ).toBe(0);
+    });
   });
 
-  it("デフォルトでキャプチャフェーズでイベントを購読すること", () => {
-    const spy = vi.spyOn(document, "addEventListener");
+  describe("実ユースケース", () => {
+    it("子要素から bubbles:true で発火した composition イベントを拾うこと", () => {
+      const input = document.createElement("input");
+      document.body.append(input);
 
-    renderHook(() => useIsComposing());
+      try {
+        const { result: capture } = renderHook(() => useIsComposing(true));
+        const { result: bubble } = renderHook(() => useIsComposing(false));
 
-    expect(spy).toHaveBeenCalledWith(
-      "compositionstart",
-      expect.any(Function),
-      true,
-    );
-    expect(spy).toHaveBeenCalledWith(
-      "compositionend",
-      expect.any(Function),
-      true,
-    );
-  });
+        act(() => {
+          input.dispatchEvent(
+            new CompositionEvent("compositionstart", { bubbles: true }),
+          );
+        });
+        expect(capture.current).toBe(true);
+        expect(bubble.current).toBe(true);
 
-  it("capture=false でバブルフェーズでイベントを購読すること", () => {
-    const spy = vi.spyOn(document, "addEventListener");
-
-    renderHook(() => useIsComposing(false));
-
-    expect(spy).toHaveBeenCalledWith(
-      "compositionstart",
-      expect.any(Function),
-      false,
-    );
-    expect(spy).toHaveBeenCalledWith(
-      "compositionend",
-      expect.any(Function),
-      false,
-    );
-  });
-
-  it("capture が異なるインスタンスは独立したstoreを持つこと", () => {
-    const { result: capture } = renderHook(() => useIsComposing(true));
-    const { result: bubble } = renderHook(() => useIsComposing(false));
-
-    act(() => {
-      dispatchComposition("compositionstart");
+        act(() => {
+          input.dispatchEvent(
+            new CompositionEvent("compositionend", { bubbles: true }),
+          );
+        });
+        expect(capture.current).toBe(false);
+        expect(bubble.current).toBe(false);
+      } finally {
+        input.remove();
+      }
     });
-    expect(capture.current).toBe(true);
-    expect(bubble.current).toBe(true);
-
-    act(() => {
-      dispatchComposition("compositionend");
-    });
-    expect(capture.current).toBe(false);
-    expect(bubble.current).toBe(false);
-  });
-
-  it("capture が変更されたとき、新しいストアの値を返すこと", () => {
-    // capture ストアのリスナーを維持してクリーンアップ可能にする
-    const helper = renderHook(() => useIsComposing(true));
-
-    const { result, rerender } = renderHook(
-      ({ capture }) => useIsComposing(capture),
-      { initialProps: { capture: true as boolean } },
-    );
-
-    act(() => {
-      dispatchComposition("compositionstart");
-    });
-    expect(result.current).toBe(true);
-
-    rerender({ capture: false });
-    // bubble ストアは composing されていないので false
-    expect(result.current).toBe(false);
-
-    // bubble ストアで compositionstart を発火すると true に戻る
-    act(() => {
-      dispatchComposition("compositionstart");
-    });
-    expect(result.current).toBe(true);
-
-    // 両ストアの composing 状態をリセット
-    act(() => {
-      dispatchComposition("compositionend");
-    });
-    helper.unmount();
-  });
-
-  it("capture 変更時にリスナーが適切に付け替えられること", () => {
-    const addSpy = vi.spyOn(document, "addEventListener");
-    const removeSpy = vi.spyOn(document, "removeEventListener");
-
-    const { rerender, unmount } = renderHook(
-      ({ capture }) => useIsComposing(capture),
-      { initialProps: { capture: true as boolean } },
-    );
-
-    expect(addSpy).toHaveBeenCalledWith(
-      "compositionstart",
-      expect.any(Function),
-      true,
-    );
-    expect(addSpy).toHaveBeenCalledWith(
-      "compositionend",
-      expect.any(Function),
-      true,
-    );
-
-    addSpy.mockClear();
-    removeSpy.mockClear();
-
-    rerender({ capture: false });
-
-    // capture リスナーが除去される
-    expect(removeSpy).toHaveBeenCalledWith(
-      "compositionstart",
-      expect.any(Function),
-      true,
-    );
-    expect(removeSpy).toHaveBeenCalledWith(
-      "compositionend",
-      expect.any(Function),
-      true,
-    );
-
-    // bubble リスナーが追加される
-    expect(addSpy).toHaveBeenCalledWith(
-      "compositionstart",
-      expect.any(Function),
-      false,
-    );
-    expect(addSpy).toHaveBeenCalledWith(
-      "compositionend",
-      expect.any(Function),
-      false,
-    );
-
-    unmount();
-  });
-
-  it("アンマウント後はイベントに反応しないこと", () => {
-    const { result, unmount } = renderHook(() => useIsComposing());
-    unmount();
-
-    act(() => {
-      dispatchComposition("compositionstart");
-    });
-    expect(result.current).toBe(false);
   });
 });

--- a/src/hooks/useIsComposing/useIsComposing.ts
+++ b/src/hooks/useIsComposing/useIsComposing.ts
@@ -1,83 +1,12 @@
 import { useSyncExternalStore } from "react";
-
-interface Store {
-  composing: boolean;
-  callbacks: Set<() => void>;
-  onCompositionStart: () => void;
-  onCompositionEnd: () => void;
-}
-
-const stores = new Map<boolean, Store>();
-
-function getStore(capture: boolean): Store {
-  const existing = stores.get(capture);
-  if (existing) {
-    return existing;
-  }
-
-  const store: Store = {
-    composing: false,
-    callbacks: new Set(),
-    onCompositionStart: () => {
-      store.composing = true;
-      for (const notify of store.callbacks) {
-        notify();
-      }
-    },
-    onCompositionEnd: () => {
-      store.composing = false;
-      for (const notify of store.callbacks) {
-        notify();
-      }
-    },
-  };
-
-  stores.set(capture, store);
-  return store;
-}
-
-function subscribe(capture: boolean, onStoreChange: () => void) {
-  const store = getStore(capture);
-
-  if (store.callbacks.size === 0) {
-    document.addEventListener(
-      "compositionstart",
-      store.onCompositionStart,
-      capture,
-    );
-    document.addEventListener(
-      "compositionend",
-      store.onCompositionEnd,
-      capture,
-    );
-  }
-  store.callbacks.add(onStoreChange);
-  return () => {
-    store.callbacks.delete(onStoreChange);
-    if (store.callbacks.size === 0) {
-      document.removeEventListener(
-        "compositionstart",
-        store.onCompositionStart,
-        capture,
-      );
-      document.removeEventListener(
-        "compositionend",
-        store.onCompositionEnd,
-        capture,
-      );
-    }
-  };
-}
+import { bubbleCompositionStore, captureCompositionStore } from "./utils";
 
 /**
- * テキストの編集中にユーザーがテキストの作成中かどうかを判定するカスタムフック
+ * IME 変換中かどうかを返すフック。
  *
- * @param capture - キャプチャフェーズでイベントを購読するかどうか (デフォルト: true)
+ * @param capture - キャプチャフェーズで composition イベントを購読するかどうか
  */
 export function useIsComposing(capture = true): boolean {
-  return useSyncExternalStore(
-    (onStoreChange) => subscribe(capture, onStoreChange),
-    () => getStore(capture).composing,
-    () => false,
-  );
+  const store = capture ? captureCompositionStore : bubbleCompositionStore;
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, () => false);
 }

--- a/src/hooks/useIsComposing/utils/compositionStore.test.ts
+++ b/src/hooks/useIsComposing/utils/compositionStore.test.ts
@@ -1,0 +1,314 @@
+import { bubbleCompositionStore, captureCompositionStore } from ".";
+import { createCompositionStore } from "./compositionStore";
+
+function dispatchComposition(type: "compositionstart" | "compositionend") {
+  document.dispatchEvent(new CompositionEvent(type));
+}
+
+describe("compositionStore", () => {
+  describe.for([
+    {
+      name: "captureCompositionStore",
+      store: captureCompositionStore,
+      capture: true,
+    },
+    {
+      name: "bubbleCompositionStore",
+      store: bubbleCompositionStore,
+      capture: false,
+    },
+  ])("$name", ({ store, capture }) => {
+    it("初期値はfalse", () => {
+      expect(store.getSnapshot()).toBe(false);
+    });
+
+    it("compositionstartでtrue、compositionendでfalseになる", () => {
+      const unsubscribe = store.subscribe(() => {});
+
+      dispatchComposition("compositionstart");
+      expect(store.getSnapshot()).toBe(true);
+
+      dispatchComposition("compositionend");
+      expect(store.getSnapshot()).toBe(false);
+
+      unsubscribe();
+    });
+
+    it("subscribe中のリスナーが同期的に呼ばれる", () => {
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+
+      dispatchComposition("compositionstart");
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      dispatchComposition("compositionend");
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      unsubscribe();
+    });
+
+    it("unsubscribe後はリスナーが呼ばれない", () => {
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+      unsubscribe();
+
+      dispatchComposition("compositionstart");
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("初回subscribeでdocumentリスナーを登録する", () => {
+      const addSpy = vi.spyOn(document, "addEventListener");
+
+      const unsubscribe = store.subscribe(() => {});
+
+      expect(addSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        capture,
+      );
+      expect(addSpy).toHaveBeenCalledWith(
+        "compositionend",
+        expect.any(Function),
+        capture,
+      );
+
+      unsubscribe();
+    });
+
+    it("最後のunsubscribeでdocumentリスナーを除去する", () => {
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+      const unsubscribe = store.subscribe(() => {});
+
+      unsubscribe();
+
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        capture,
+      );
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionend",
+        expect.any(Function),
+        capture,
+      );
+    });
+
+    it("購読者が複数いる間は最後の1件まで除去しない", () => {
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+      const u1 = store.subscribe(() => {});
+      const u2 = store.subscribe(() => {});
+
+      u1();
+      expect(removeSpy).not.toHaveBeenCalled();
+
+      u2();
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        capture,
+      );
+    });
+
+    it("複数リスナーが全員呼ばれる", () => {
+      const l1 = vi.fn();
+      const l2 = vi.fn();
+      const u1 = store.subscribe(l1);
+      const u2 = store.subscribe(l2);
+
+      dispatchComposition("compositionstart");
+
+      expect(l1).toHaveBeenCalledTimes(1);
+      expect(l2).toHaveBeenCalledTimes(1);
+
+      u1();
+      u2();
+    });
+
+    it("リスナー内で他のリスナーをunsubscribeしても他のリスナーは呼ばれる", () => {
+      const l2 = vi.fn();
+      const ref: { u2?: () => void } = {};
+      const l1 = vi.fn(() => {
+        ref.u2?.();
+      });
+      const u1 = store.subscribe(l1);
+      const u2 = store.subscribe(l2);
+      ref.u2 = u2;
+
+      dispatchComposition("compositionstart");
+
+      expect(l1).toHaveBeenCalledTimes(1);
+      expect(l2).toHaveBeenCalledTimes(1);
+
+      u1();
+      u2();
+    });
+
+    it("あるリスナーがthrowしても他のリスナーは呼ばれる", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const bad = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const good = vi.fn();
+      const u1 = store.subscribe(bad);
+      const u2 = store.subscribe(good);
+
+      dispatchComposition("compositionstart");
+
+      expect(bad).toHaveBeenCalledTimes(1);
+      expect(good).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      u1();
+      u2();
+    });
+
+    it("composing中にunsubscribeしても次のsubscribeはfalseから始まる", () => {
+      // 最後の unsubscribe で composing を false にリセットする挙動の回帰テスト。
+      // 購読の切れ目で compositionend を取りこぼしても、次の subscribe 時の getSnapshot が
+      // 古い true を返さないことを保証する。
+      const u1 = store.subscribe(() => {});
+      dispatchComposition("compositionstart");
+      expect(store.getSnapshot()).toBe(true);
+
+      u1();
+      // 購読者が居ない間に IME が終了しても listener は呼ばれない
+      dispatchComposition("compositionend");
+
+      const u2 = store.subscribe(() => {});
+      expect(store.getSnapshot()).toBe(false);
+
+      u2();
+    });
+  });
+
+  describe("ストア間の独立性", () => {
+    it("captureとbubbleは独立してリスナーを管理する", () => {
+      const captureListener = vi.fn();
+      const bubbleListener = vi.fn();
+      const u1 = captureCompositionStore.subscribe(captureListener);
+      const u2 = bubbleCompositionStore.subscribe(bubbleListener);
+
+      dispatchComposition("compositionstart");
+
+      // 同じ document イベントだが、capture/bubble 両方のフェーズで購読されるため両者に届く
+      expect(captureListener).toHaveBeenCalledTimes(1);
+      expect(bubbleListener).toHaveBeenCalledTimes(1);
+
+      u1();
+      u2();
+    });
+
+    it("一方のストアのunsubscribeは他方に影響しない", () => {
+      const captureListener = vi.fn();
+      const bubbleListener = vi.fn();
+      const u1 = captureCompositionStore.subscribe(captureListener);
+      const u2 = bubbleCompositionStore.subscribe(bubbleListener);
+
+      u1();
+
+      dispatchComposition("compositionstart");
+
+      expect(captureListener).not.toHaveBeenCalled();
+      expect(bubbleListener).toHaveBeenCalledTimes(1);
+
+      u2();
+    });
+  });
+
+  describe("createCompositionStore (ファクトリ)", () => {
+    it("同じ capture 値でも独立したインスタンスを返す", () => {
+      const a = createCompositionStore(true);
+      const b = createCompositionStore(true);
+      const listenerA = vi.fn();
+      const listenerB = vi.fn();
+
+      const uA = a.subscribe(listenerA);
+      const uB = b.subscribe(listenerB);
+
+      uA();
+
+      dispatchComposition("compositionstart");
+
+      expect(listenerA).not.toHaveBeenCalled();
+      expect(listenerB).toHaveBeenCalledTimes(1);
+      expect(a.getSnapshot()).toBe(false);
+      expect(b.getSnapshot()).toBe(true);
+
+      uB();
+    });
+
+    it("capture 引数が addEventListener の第3引数にそのまま渡される", () => {
+      const addSpy = vi.spyOn(document, "addEventListener");
+      const store = createCompositionStore(false);
+
+      const unsubscribe = store.subscribe(() => {});
+
+      expect(addSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        false,
+      );
+      expect(addSpy).toHaveBeenCalledWith(
+        "compositionend",
+        expect.any(Function),
+        false,
+      );
+
+      unsubscribe();
+    });
+
+    it("同一インスタンスに対する unsubscribe の多重呼び出しは冪等", () => {
+      const store = createCompositionStore(true);
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+
+      const unsubscribe = store.subscribe(() => {});
+      unsubscribe();
+      unsubscribe();
+
+      // removeEventListener は最初の unsubscribe の1回のみ
+      // compositionstart + compositionend で計 2 回
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("同一 listener を多重 subscribe しても各セッションが独立して扱われる", () => {
+      const store = createCompositionStore(true);
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+      const listener = vi.fn();
+
+      const u1 = store.subscribe(listener);
+      const u2 = store.subscribe(listener);
+
+      // 1 回目の unsubscribe では document リスナーは外れない
+      u1();
+      expect(removeSpy).not.toHaveBeenCalled();
+
+      // 2 回目のセッションはまだ有効なのでイベントが届く
+      dispatchComposition("compositionstart");
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // 最後の unsubscribe で document リスナー除去
+      u2();
+      expect(removeSpy).toHaveBeenCalledWith(
+        "compositionstart",
+        expect.any(Function),
+        true,
+      );
+    });
+
+    it("同一 listener を多重 subscribe した場合、各セッションに対して通知される", () => {
+      const store = createCompositionStore(true);
+      const listener = vi.fn();
+
+      const u1 = store.subscribe(listener);
+      const u2 = store.subscribe(listener);
+
+      dispatchComposition("compositionstart");
+
+      // 2 セッション分通知されるので計 2 回呼ばれる
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      u1();
+      u2();
+    });
+  });
+});

--- a/src/hooks/useIsComposing/utils/compositionStore.ts
+++ b/src/hooks/useIsComposing/utils/compositionStore.ts
@@ -1,0 +1,91 @@
+/**
+ * `document` の composition イベントを購読し、IME 変換中状態を共有するストア。
+ * `useSyncExternalStore` にそのまま渡せる `subscribe` / `getSnapshot` を返す。
+ */
+
+interface CompositionStore {
+  getSnapshot: () => boolean;
+  subscribe: (listener: () => void) => () => void;
+}
+
+/** Listener の throw が他セッションへの通知を止めないよう握りつぶす。 */
+function invoke(listener: () => void): void {
+  try {
+    listener();
+  } catch (error) {
+    console.error("compositionStore listener threw:", error);
+  }
+}
+
+/**
+ * 初回 subscribe で document リスナーを install、最後の subscriber が抜けた
+ * タイミングで remove する参照カウント方式のストアを生成する。
+ */
+export function createCompositionStore(capture: boolean): CompositionStore {
+  let composing = false;
+  const listeners = new Set<() => void>();
+
+  const notify = (): void => {
+    // リスナー内で subscribe/unsubscribe が起きても安全なようスナップショットを取る
+    const snapshot = [...listeners];
+    for (const sessionListener of snapshot) {
+      sessionListener();
+    }
+  };
+
+  const onCompositionStart = (): void => {
+    composing = true;
+    notify();
+  };
+
+  const onCompositionEnd = (): void => {
+    composing = false;
+    notify();
+  };
+
+  const subscribe = (listener: () => void): (() => void) => {
+    if (listeners.size === 0) {
+      document.addEventListener(
+        "compositionstart",
+        onCompositionStart,
+        capture,
+      );
+      document.addEventListener("compositionend", onCompositionEnd, capture);
+    }
+    // 同一 listener 参照を多重 subscribe しても Set の重複排除で潰されないよう、
+    // セッションごとに一意のラッパーを登録する
+    const sessionListener = (): void => {
+      invoke(listener);
+    };
+    listeners.add(sessionListener);
+
+    let unsubscribed = false;
+    return () => {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+      listeners.delete(sessionListener);
+      if (listeners.size === 0) {
+        // 購読切れ目の compositionend を取りこぼしても次回 subscribe 時に
+        // 古い true を引きずらないよう、ここでフラグを初期化する
+        composing = false;
+        document.removeEventListener(
+          "compositionstart",
+          onCompositionStart,
+          capture,
+        );
+        document.removeEventListener(
+          "compositionend",
+          onCompositionEnd,
+          capture,
+        );
+      }
+    };
+  };
+
+  return {
+    getSnapshot: () => composing,
+    subscribe,
+  };
+}

--- a/src/hooks/useIsComposing/utils/index.ts
+++ b/src/hooks/useIsComposing/utils/index.ts
@@ -1,0 +1,4 @@
+import { createCompositionStore } from "./compositionStore";
+
+export const captureCompositionStore = createCompositionStore(true);
+export const bubbleCompositionStore = createCompositionStore(false);


### PR DESCRIPTION
## Summary

- `useIsComposing` 内にあった capture/bubble 用の Map ベースのストアを `utils/compositionStore` に切り出し、フック本体は `useSyncExternalStore` でストアを選ぶだけの薄い層に整理
- ストアは React 非依存のため単体テスト可能。購読切れ目で `composing` フラグをリセットする挙動（購読者不在中に `compositionend` を取りこぼしても次回マウント時に `true` を引きずらない）を契約として明示化し、回帰テストを追加
- フックのテストを `describe` で階層化（基本動作 / ストア選択 / 購読ライフサイクル / 実ユースケース）。store と重複する観点を削除し、`capture` パラメトライズは `it.for`、StrictMode 下のリスナーリークチェック、子要素からの `bubbles:true` 経路、`composing` 中 unmount → 再 mount の回帰テストを追加
- Storybook は capture → target → bubble の発火順を目視確認できるデモに刷新

## Test plan

- [x] `pnpm vitest run src/hooks/useIsComposing` — 40 件グリーン
- [x] `pnpm check` — lint / fmt / knip パス
- [ ] Storybook で IME 入力した際に capture → target → bubble の順序でログが記録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)