### PR TITLE
chore: add Renovate + lefthook support for APM

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>devmgn/renovate-config"]
+  "extends": ["github>devmgn/renovate-config"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/apm\\.ya?ml$/"],
+      "matchStrings": [
+        "-\\s+(?<depName>[^/\\s]+/[^/\\s]+)/[^#\\s]+#(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/{{{depName}}}",
+      "currentValueTemplate": "main"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["apm.yml"],
+      "groupName": "APM agent skills",
+      "commitMessageTopic": "APM skill {{depName}}",
+      "automerge": false
+    }
+  ]
 }

--- a/.github/workflows/apm-lock.yml
+++ b/.github/workflows/apm-lock.yml
@@ -1,0 +1,54 @@
+name: Update APM lockfile
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+    paths:
+      - "apm.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  Update-Lock:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.ref }}
+          persist-credentials: false
+
+      - name: Install apm
+        run: |
+          curl -sSL https://aka.ms/apm-unix | sh
+          for dir in "$HOME/.local/bin" "$HOME/.apm/bin" "/usr/local/bin"; do
+            if [ -x "$dir/apm" ]; then echo "$dir" >> "$GITHUB_PATH"; break; fi
+          done
+
+      - name: Verify apm
+        run: apm --version
+
+      - name: Regenerate apm.lock.yaml
+        run: apm install -t claude
+
+      - name: Commit and push if lock changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain apm.lock.yaml)" ]; then
+            echo "apm.lock.yaml is already up to date."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add apm.lock.yaml
+          git commit -m "chore: regenerate apm.lock.yaml"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"

--- a/apm.yml
+++ b/apm.yml
@@ -1,7 +1,5 @@
 name: nextjs-boilerplate
 version: 1.0.0
-description: APM project for nextjs-boilerplate
-author: JUNICHI IMAI
 dependencies:
   apm:
     - vercel-labs/agent-skills/skills/react-best-practices#ce3e64e468f8fa09a2d075d102771838061fdac0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -45,3 +45,7 @@ post-merge:
       files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
       glob: "pnpm-lock.yaml"
       run: pnpm install
+    - name: apm-install-on-change
+      files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
+      glob: "apm.{yml,lock.yaml}"
+      run: apm install -t claude


### PR DESCRIPTION
## Summary

Follow-up to #2734 (APM migration) — wire up automated update flow.

- **Renovate customManager**: Tracks 40-char SHAs in `apm.yml` for both `vercel-labs/agent-skills` and `antfu/skills` (default branch `main`) via `git-refs` datasource. Both repos are grouped into a single PR. `automerge: false` (skill changes directly affect AI behavior — manual review).
- **GitHub Actions** (`apm-lock.yml`): On `push` to `renovate/**` that touches `apm.yml`, install apm CLI, regenerate `apm.lock.yaml` via `apm install -t claude`, and commit/push back to the same branch. Mend Cloud Renovate does not allow `postUpgrade` commands, so this side-channel keeps lock and yml in sync within the same PR.
- **Lefthook** `post-merge`: When `apm.yml` or `apm.lock.yaml` change (after `git pull` / merge), run `apm install -t claude` to refresh `.claude/skills/`. Mirrors the existing `install-on-lockfile-change` pattern for `pnpm-lock.yaml`.

## Notes

- Renovate PR push uses the default `GITHUB_TOKEN` with `contents: write`. The push from this workflow does **not** trigger another workflow run (default GitHub safety), so no infinite loop.
- `persist-credentials: false` on checkout (repo convention); push step authenticates via `x-access-token` URL with the token in `env`, not interpolated into the run script.
- `apm` CLI install path is probed across `~/.local/bin`, `~/.apm/bin`, `/usr/local/bin` and added to `GITHUB_PATH`.

## Test plan

- [ ] After merge, the next Renovate run should propose a PR bumping SHAs in `apm.yml`
- [ ] On that PR, the `Update APM lockfile` workflow should run and add a follow-up commit updating `apm.lock.yaml`
- [ ] After pulling main with apm changes, `lefthook` post-merge should auto-run `apm install -t claude` and refresh `.claude/skills/`
- [ ] `pnpm lint:workflows` (actionlint + zizmor) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)