### PR TITLE
chore(oxlint): プラグインルールのドリフト検出テスト追加と設定棚卸し

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -156,29 +156,25 @@ export default defineConfig({
     "@tanstack/query/no-rest-destructuring": "error",
     "@tanstack/query/no-unstable-deps": "error",
     "@tanstack/query/no-void-query-fn": "error",
+    "@tanstack/query/prefer-query-options": "error",
     "@tanstack/query/stable-query-client": "error",
 
     // ── react-compiler-rules (jsPlugin: eslint-plugin-react-hooks) ──
     "react-compiler-rules/capitalized-calls": "error",
-    "react-compiler-rules/component-hook-factories": "error",
     "react-compiler-rules/config": "error",
     "react-compiler-rules/error-boundaries": "error",
-    "react-compiler-rules/gating": "error",
     "react-compiler-rules/globals": "error",
-    "react-compiler-rules/hooks": "error",
     "react-compiler-rules/immutability": "error",
-    "react-compiler-rules/incompatible-library": "error",
+    "react-compiler-rules/incompatible-library": "warn",
     "react-compiler-rules/memoized-effect-dependencies": "error",
     "react-compiler-rules/no-deriving-state-in-effects": "error",
     "react-compiler-rules/preserve-manual-memoization": "error",
     "react-compiler-rules/purity": "error",
     "react-compiler-rules/refs": "error",
-    "react-compiler-rules/rule-suppression": "error",
     "react-compiler-rules/set-state-in-effect": "error",
     "react-compiler-rules/set-state-in-render": "error",
     "react-compiler-rules/static-components": "error",
-    "react-compiler-rules/syntax": "error",
-    "react-compiler-rules/unsupported-syntax": "error",
+    "react-compiler-rules/unsupported-syntax": "warn",
     "react-compiler-rules/use-memo": "error",
     "react-compiler-rules/void-use-memo": "error",
 
@@ -227,6 +223,9 @@ export default defineConfig({
         "storybook/story-exports": "error",
         "storybook/use-storybook-expect": "error",
         "storybook/use-storybook-testing-library": "error",
+
+        // ── @tanstack/eslint-plugin-query (jsPlugin) ──
+        "@tanstack/query/prefer-query-options": "off",
       },
       jsPlugins: ["eslint-plugin-storybook"],
     },
@@ -253,7 +252,7 @@ export default defineConfig({
       },
     },
     {
-      // Next.js special files + config files → allow default export, relax filename
+      // default export を許可するファイル群:
       files: [
         ".storybook/main.ts",
         ".storybook/preview.tsx",
@@ -261,30 +260,13 @@ export default defineConfig({
         "oxfmt.config.ts",
         "oxlint.config.ts",
         "postcss.config.mjs",
-        "src/**/default.tsx",
-        "src/**/error.tsx",
-        "src/**/forbidden.tsx",
-        "src/**/global-error.tsx",
-        "src/**/instrumentation-client.ts",
-        "src/**/instrumentation.ts",
-        "src/**/layout.tsx",
-        "src/**/loading.tsx",
-        "src/**/not-found.tsx",
-        "src/**/page.tsx",
-        "src/**/proxy.ts",
-        "src/**/sitemap.ts",
-        "src/**/template.tsx",
-        "src/**/unauthorized.tsx",
         "vitest.config.ts",
         "vitest.globalSetup.ts",
+        // Next.js 規約ファイル (vitest.config.ts と同じ brace glob スタイル)
+        "src/**/{default,error,forbidden,global-error,layout,loading,not-found,page,template,unauthorized}.tsx",
+        "src/**/{instrumentation-client,instrumentation,proxy,sitemap}.ts",
+        "tools/oxlint-rules/**/*.ts",
       ],
-      rules: {
-        "import/no-default-export": "off",
-      },
-    },
-    {
-      // Custom oxlint rule plugin entries — default exports are required by the plugin loader
-      files: ["tools/oxlint-rules/**/*.ts"],
       rules: {
         "import/no-default-export": "off",
       },

--- a/tools/oxlint-rules/oxlint.config.test.ts
+++ b/tools/oxlint-rules/oxlint.config.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import oxlintConfig from "../../oxlint.config.ts";
+
+// 外部 jsPlugin（tanstack / storybook / react-hooks）は config にルールを手動列挙しているため、
+// プラグイン更新で増えた新ルールを取りこぼしうる（前方ドリフト）。それを検出して採用/除外の判断を促す。
+// 実在しないルール名は oxlint が config パース時に弾くため、後方ドリフトは扱わない。
+
+interface PluginLike {
+  rules?: Record<string, unknown>;
+}
+type JsPluginEntry = string | { name?: string; specifier: string };
+
+// config に載せない外部ルールと、その理由。
+const IGNORED_RULES = new Set<string>([
+  // oxlint native の react ルールと重複
+  "react-compiler-rules/rules-of-hooks",
+  "react-compiler-rules/hooks",
+  "react-compiler-rules/exhaustive-deps",
+  // 依存検証（opt-in）。React Compiler 有効環境では不要
+  "react-compiler-rules/memo-dependencies",
+  "react-compiler-rules/exhaustive-effect-dependencies",
+  // コンパイラ内部診断でコード規則ではない
+  "react-compiler-rules/invariant",
+  "react-compiler-rules/todo",
+  // fbt（Meta の i18n）未使用
+  "react-compiler-rules/fbt",
+  // 削除済み（deprecated）
+  "react-compiler-rules/component-hook-factories",
+  // gating モード未使用
+  "react-compiler-rules/gating",
+  // 正当な suppression まで禁じるため不採用
+  "react-compiler-rules/rule-suppression",
+  // 構文診断系でノイズになりうる
+  "react-compiler-rules/syntax",
+]);
+
+// プラグイン specifier → oxlint の前缀（eslint-plugin-x → x ／ @scope/eslint-plugin-x → @scope/x）。
+function stripEslintPluginPrefix(name: string): string {
+  const marker = "eslint-plugin-";
+  return name.startsWith(marker) ? name.slice(marker.length) : name;
+}
+
+function normalizePluginPrefix(specifier: string): string {
+  if (!specifier.startsWith("@")) {
+    return stripEslintPluginPrefix(specifier);
+  }
+  const slash = specifier.indexOf("/");
+  const scope = specifier.slice(0, slash);
+  const rest = specifier.slice(slash + 1);
+  return rest === "eslint-plugin"
+    ? scope
+    : `${scope}/${stripEslintPluginPrefix(rest)}`;
+}
+
+// config の jsPlugins（top-level + overrides）を集める。
+function collectJsPluginEntries(): JsPluginEntry[] {
+  const entries: JsPluginEntry[] = [
+    ...(oxlintConfig.jsPlugins as JsPluginEntry[]),
+  ];
+  for (const override of oxlintConfig.overrides) {
+    const overridePlugins = override.jsPlugins as JsPluginEntry[] | undefined;
+    if (overridePlugins !== undefined) {
+      entries.push(...overridePlugins);
+    }
+  }
+  return entries;
+}
+
+// entry → { 前缀, specifier }。相対パス（自作プラグイン）は除外。
+function resolveExternalPlugin(
+  entry: JsPluginEntry,
+): { prefix: string; specifier: string } | undefined {
+  const specifier = typeof entry === "string" ? entry : entry.specifier;
+  if (specifier.startsWith(".")) {
+    return undefined;
+  }
+  const explicitName = typeof entry === "string" ? undefined : entry.name;
+  return {
+    prefix: `${explicitName ?? normalizePluginPrefix(specifier)}/`,
+    specifier,
+  };
+}
+
+// config だけから求まる外部 jsPlugin の前缀集合（読み込み結果の照合用）。
+function declaredExternalPrefixes(): Set<string> {
+  const prefixes = new Set<string>();
+  for (const entry of collectJsPluginEntries()) {
+    const resolved = resolveExternalPlugin(entry);
+    if (resolved !== undefined) {
+      prefixes.add(resolved.prefix);
+    }
+  }
+  return prefixes;
+}
+
+// 前缀 → プラグインが公開する全ルール名。
+async function buildExternalPlugins(): Promise<Record<string, string[]>> {
+  // 前缀で重複排除（overrides の storybook 等）してから並列に import する。
+  const byPrefix = new Map<string, string>();
+  for (const entry of collectJsPluginEntries()) {
+    const resolved = resolveExternalPlugin(entry);
+    if (resolved !== undefined && !byPrefix.has(resolved.prefix)) {
+      byPrefix.set(resolved.prefix, resolved.specifier);
+    }
+  }
+  const loaded = await Promise.all(
+    [...byPrefix].map(async ([prefix, specifier]) => {
+      const mod = (await import(specifier)) as {
+        default?: PluginLike;
+      } & PluginLike;
+      const plugin = mod.default ?? mod;
+      return [prefix, Object.keys(plugin.rules ?? {})] as const;
+    }),
+  );
+  return Object.fromEntries(loaded);
+}
+
+// top-level と overrides 両方の rules キーを集める（storybook は overrides にのみ現れる）。
+function collectConfiguredRuleNames(): Set<string> {
+  const names = new Set<string>();
+  function addAll(rules: Record<string, unknown> | undefined): void {
+    for (const name of Object.keys(rules ?? {})) {
+      names.add(name);
+    }
+  }
+  addAll(oxlintConfig.rules as Record<string, unknown> | undefined);
+  for (const override of oxlintConfig.overrides) {
+    addAll(override.rules as Record<string, unknown> | undefined);
+  }
+  return names;
+}
+
+function untriagedRules(
+  prefix: string,
+  ruleNames: readonly string[],
+  configured: ReadonlySet<string>,
+): string[] {
+  return ruleNames
+    .map((name) => `${prefix}${name}`)
+    .filter((key) => !configured.has(key) && !IGNORED_RULES.has(key));
+}
+
+const externalPlugins = await buildExternalPlugins();
+
+describe("oxlint config ↔ プラグイン整合性 (前方ドリフト検出)", () => {
+  const configured = collectConfiguredRuleNames();
+
+  it("config 宣言の外部 jsPlugin を全て読み込めている", () => {
+    const declared = declaredExternalPrefixes();
+    // 0 件だと it.each が空になり素通りするためのガード。
+    expect(declared.size).toBeGreaterThan(0);
+    expect(new Set(Object.keys(externalPlugins))).toStrictEqual(declared);
+  });
+
+  it.each(Object.entries(externalPlugins))(
+    "%s の全公開ルールが設定済 or 許可リストにある",
+    (prefix, ruleNames) => {
+      // import 形状の退行で空配列＝素通りになるのを防ぐ。
+      expect(
+        ruleNames.length,
+        `${prefix} のルールが読めていない（プラグインの import 形状が変わった可能性）`,
+      ).toBeGreaterThan(0);
+
+      const untriaged = untriagedRules(prefix, ruleNames, configured);
+      expect(
+        untriaged,
+        `未 triage の新ルール（config 追加 or 許可リスト登録が必要）: ${untriaged.join(", ")}`,
+      ).toStrictEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
## 概要

oxlint 設定の棚卸しと、手動列挙している外部 jsPlugin ルールの**ドリフト検出を自動化**する。

## 背景

`oxlint.config.ts` は built-in を `categories` で自動追従させる一方、外部 jsPlugin（tanstack / storybook / react-hooks）はルールを手動列挙している。手動列挙はプラグイン更新で「新ルールが増えたのに config が取りこぼす」前方ドリフトを起こすが、oxlint 自身は検知できない。これを CI で検出する仕組みを足しつつ、既存設定を精査した。

## 変更点

### ドリフト検出テスト（新規）
- `tools/oxlint-rules/oxlint.config.test.ts` を追加。`config.jsPlugins` 宣言から外部プラグインを自動導出し、「公開ルール ⊆ (config 設定済 ∪ IGNORED_RULES)」を検証。新ルールの取りこぼしを CI（`test:oxlint-rules`）で fail させ、採用 or 明示除外の triage を強制する。
- 後方ドリフト（死指定）は oxlint が config パースで弾くため対象外。

### 設定の棚卸し
- `@tanstack/query/prefer-query-options` を採用（取りこぼしていた新ルール）。stories はデモ用途のため off。
- `import/no-default-export` の overrides を統合し、Next.js 規約ファイルを brace glob 化（`vitest.config.ts` と同スタイル）。

### react-compiler-rules の精査
- 削除済み（deprecated）の `component-hook-factories` を除去。
- native `react/rules-of-hooks` と二重報告する `hooks` を無効化。
- 未使用/診断系の `gating` / `rule-suppression` / `syntax` を除外。
- `incompatible-library` / `unsupported-syntax` を公式 severity の `warn` に。

## 検証
- `pnpm check`（oxlint + oxfmt + knip）クリーン
- `pnpm test:oxlint-rules` 77 pass / `pnpm test:unit` 422 pass・型エラー無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)