### PR TITLE
refactor(debounce): trailing + cancel/flush の最小構成に再設計

### DIFF
--- a/src/hooks/useDebouncedCallback/useDebouncedCallback.stories.tsx
+++ b/src/hooks/useDebouncedCallback/useDebouncedCallback.stories.tsx
@@ -2,7 +2,42 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useId, useState } from "react";
 import { useDebouncedCallback } from "./useDebouncedCallback";
 import { Input } from "../../components/form/Input";
-import { useIsComposing } from "../useIsComposing";
+
+/** Result 表示と delay 入力の共通シェル。各 story はここにテキスト入力を差し込む。 */
+function DemoShell({
+  result,
+  delayTime,
+  onDelayChange,
+  children,
+}: {
+  result: string;
+  delayTime: number;
+  onDelayChange: (ms: number) => void;
+  children: React.ReactNode;
+}) {
+  const resultId = useId();
+  const delayTimeId = useId();
+
+  return (
+    <div className="flex flex-col gap-4">
+      {children}
+      <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+        <label htmlFor={resultId}>debounced result: </label>
+        <Input id={resultId} readOnly value={result} />
+        <label htmlFor={delayTimeId}>delay (ms)</label>
+        <Input
+          id={delayTimeId}
+          onChange={(e) => {
+            onDelayChange(e.target.valueAsNumber);
+          }}
+          placeholder="delay time"
+          type="number"
+          value={delayTime}
+        />
+      </div>
+    </div>
+  );
+}
 
 const meta = {
   component: undefined,
@@ -10,58 +45,71 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  render: () => {
-    const [delayTime, setDelayTime] = useState(250);
-    const [result, setResult] = useState("");
-
-    const resultId = useId();
-    const delayTimeId = useId();
-
-    const isComposing = useIsComposing();
-
-    const onChange = useDebouncedCallback(
-      (
-        e:
-          | React.ChangeEvent<HTMLInputElement>
-          | React.CompositionEvent<HTMLInputElement>,
-      ) => {
-        if (!isComposing && e.target instanceof HTMLInputElement) {
-          setResult(e.target.value);
-        }
-      },
-      delayTime,
-    );
-
-    return (
-      <div className="flex flex-col gap-4">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-          <label htmlFor={resultId}>debouncedValue Result: </label>
-          <Input id={resultId} readOnly value={result} />
-          <label htmlFor={delayTimeId}>DelayTime</label>
-          <Input
-            id={delayTimeId}
-            onChange={(e) => {
-              setDelayTime(Number(e.target.value));
-            }}
-            placeholder="delay time"
-            type="number"
-            value={delayTime}
-          />
-        </div>
-        <Input
-          onChange={onChange}
-          onCompositionEnd={(e) => {
-            onChange(e);
-            onChange.flush();
-          }}
-          placeholder="input text"
-        />
-      </div>
-    );
-  },
 } satisfies Meta<typeof useDebouncedCallback>;
 
 export default meta;
 type Story = StoryObj<typeof useDebouncedCallback>;
 
-export const Default: Story = {};
+/** 入力が止まってから delay 経過後に result が更新される、純粋な debounce デモ。 */
+export const Default: Story = {
+  render: () => {
+    const [delayTime, setDelayTime] = useState(250);
+    const [result, setResult] = useState("");
+
+    const onChange = useDebouncedCallback((value: string) => {
+      setResult(value);
+    }, delayTime);
+
+    return (
+      <DemoShell
+        delayTime={delayTime}
+        onDelayChange={setDelayTime}
+        result={result}
+      >
+        <Input
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
+          placeholder="input text"
+        />
+      </DemoShell>
+    );
+  },
+};
+
+/** IME 対応デモ。変換中の中間入力は debounce に流さず、変換確定時 (compositionEnd) に flush で即時反映する。 */
+export const WithIme: Story = {
+  render: () => {
+    const [delayTime, setDelayTime] = useState(250);
+    const [result, setResult] = useState("");
+
+    const onChange = useDebouncedCallback((value: string) => {
+      setResult(value);
+    }, delayTime);
+
+    return (
+      <DemoShell
+        delayTime={delayTime}
+        onDelayChange={setDelayTime}
+        result={result}
+      >
+        <Input
+          onChange={(e) => {
+            // 発火時点の正確な変換状態を nativeEvent から読む（render スナップショットは1テンポ古い）
+            const { nativeEvent } = e;
+            if (nativeEvent instanceof InputEvent && nativeEvent.isComposing) {
+              return;
+            }
+            onChange(e.target.value);
+          }}
+          onCompositionEnd={(e) => {
+            // 変換確定時は即時反映
+            onChange(e.currentTarget.value);
+            onChange.flush();
+          }}
+          placeholder="input text (IME 対応)"
+        />
+      </DemoShell>
+    );
+  },
+};

--- a/src/hooks/useDebouncedCallback/useDebouncedCallback.test.ts
+++ b/src/hooks/useDebouncedCallback/useDebouncedCallback.test.ts
@@ -58,7 +58,7 @@ describe(useDebouncedCallback, () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it("コンポーネントのアンマウント時にdebouncedFnがキャンセルされること", () => {
+  it("コンポーネントのアンマウント時に保留中の実行がキャンセルされること", () => {
     const callback = vi.fn();
     const { result, unmount } = renderHook(() =>
       useDebouncedCallback(callback, 500),
@@ -91,28 +91,6 @@ describe(useDebouncedCallback, () => {
     expect(callback).toHaveBeenCalledExactlyOnceWith("test", 123);
   });
 
-  it("edges: ['leading', 'trailing'] オプションで先頭と末尾の両方で実行されること", () => {
-    const callback = vi.fn();
-    const { result } = renderHook(() =>
-      useDebouncedCallback(callback, 500, { edges: ["leading", "trailing"] }),
-    );
-
-    act(() => {
-      result.current();
-    });
-    expect(callback).toHaveBeenCalledTimes(1);
-
-    act(() => {
-      result.current();
-    });
-    expect(callback).toHaveBeenCalledTimes(1);
-
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-    expect(callback).toHaveBeenCalledTimes(2);
-  });
-
   it("wait が変更されると新しい debounced 関数が生成されること", () => {
     const callback = vi.fn();
     const { result, rerender } = renderHook(
@@ -142,88 +120,6 @@ describe(useDebouncedCallback, () => {
       vi.advanceTimersByTime(1000);
     });
     expect(callback).toHaveBeenCalledTimes(1);
-  });
-
-  it("schedule メソッドで保留中のタイマーが延長され lastArgs が保持されること", () => {
-    const callback = vi.fn();
-    const { result } = renderHook(() => useDebouncedCallback(callback, 500));
-
-    act(() => {
-      result.current("test");
-    });
-
-    // 発火直前まで進める
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    expect(callback).not.toHaveBeenCalled();
-
-    // schedule でタイマーを再スタート
-    act(() => {
-      result.current.schedule();
-    });
-
-    // 旧タイマーが発火するはずの時間を過ぎても未発火
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-    expect(callback).not.toHaveBeenCalled();
-
-    // 新タイマー分の経過で lastArgs を保持したまま発火
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    expect(callback).toHaveBeenCalledExactlyOnceWith("test");
-  });
-
-  it("edges: ['leading'] オプションで先頭のみ実行され trailing は発火しないこと", () => {
-    const callback = vi.fn();
-    const { result } = renderHook(() =>
-      useDebouncedCallback(callback, 500, { edges: ["leading"] }),
-    );
-
-    act(() => {
-      result.current();
-    });
-    expect(callback).toHaveBeenCalledTimes(1);
-
-    // クールダウン中の呼び出しは発火しない
-    act(() => {
-      result.current();
-    });
-    expect(callback).toHaveBeenCalledTimes(1);
-
-    // trailing 無効なのでタイマー経過後も追加発火なし
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-    expect(callback).toHaveBeenCalledTimes(1);
-  });
-
-  it("AbortSignal が abort されると保留中および以降の呼び出しが無効化されること", () => {
-    const callback = vi.fn();
-    const controller = new AbortController();
-    const { result } = renderHook(() =>
-      useDebouncedCallback(callback, 500, { signal: controller.signal }),
-    );
-
-    act(() => {
-      result.current();
-    });
-
-    // abort で保留中の実行がキャンセルされる
-    act(() => {
-      controller.abort();
-      vi.advanceTimersByTime(500);
-    });
-    expect(callback).not.toHaveBeenCalled();
-
-    // abort 後の呼び出しも無効
-    act(() => {
-      result.current();
-      vi.advanceTimersByTime(500);
-    });
-    expect(callback).not.toHaveBeenCalled();
   });
 
   it("依存が変化しない再レンダリングで同一の debounced 関数が返されること", () => {
@@ -269,57 +165,5 @@ describe(useDebouncedCallback, () => {
 
     // 最新の callback (value=1) で、保持された引数 "args" で発火する
     expect(spy).toHaveBeenCalledExactlyOnceWith(1, "args");
-  });
-
-  it("options.edges の配列参照が毎レンダリング変わっても、内容が同じなら同一 debounced 関数が返ること", () => {
-    const callback = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ edges }) =>
-        useDebouncedCallback(callback, 500, {
-          edges,
-        }),
-      { initialProps: { edges: ["leading"] as Array<"leading" | "trailing"> } },
-    );
-
-    const prev = result.current;
-    // 内容は同じで新しい配列参照を渡す
-    rerender({
-      edges: ["leading"] as Array<"leading" | "trailing">,
-    });
-
-    expect(result.current).toBe(prev);
-  });
-
-  it("edges が undefined と ['trailing'] (default 相当) で同一 debounced を返すこと", () => {
-    const callback = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ edges }: { edges: Array<"leading" | "trailing"> | undefined }) =>
-        useDebouncedCallback(callback, 500, { edges }),
-      {
-        initialProps: {
-          edges: undefined as Array<"leading" | "trailing"> | undefined,
-        },
-      },
-    );
-
-    const prev = result.current;
-    rerender({ edges: ["trailing"] });
-    expect(result.current).toBe(prev);
-  });
-
-  it("edges の順序が異なっても内容が同じなら同一 debounced を返すこと", () => {
-    const callback = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ edges }) => useDebouncedCallback(callback, 500, { edges }),
-      {
-        initialProps: {
-          edges: ["leading", "trailing"] as Array<"leading" | "trailing">,
-        },
-      },
-    );
-
-    const prev = result.current;
-    rerender({ edges: ["trailing", "leading"] });
-    expect(result.current).toBe(prev);
   });
 });

--- a/src/hooks/useDebouncedCallback/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback/useDebouncedCallback.ts
@@ -1,50 +1,33 @@
-import type { DebounceOptions } from "../../utils/debounce";
 import { useEffect, useMemo, useRef } from "react";
 import { debounce } from "../../utils/debounce";
 
 /**
  * 最新の `callback` 参照を ref で保持することで、インラインのアロー関数を渡しても
- * 保留中のタイマー・leading クールダウン状態が失われないようにする。
- * debounced 関数は `wait`/`edges`/`signal`/`maxWait` が変化したときだけ再生成される。
- * `edges` は boolean 正規化しているため `undefined` と `["trailing"]`、
- * `["leading","trailing"]` と `["trailing","leading"]` はそれぞれ同じ扱いになる。
+ * 保留中のタイマーが失われないようにする。
+ * debounced 関数は `wait` が変化したときだけ再生成される。このとき古い debounced は
+ * cleanup の cancel() で破棄されるため、保留中の1回は発火せず捨てられる。
  */
 export function useDebouncedCallback<Args extends unknown[]>(
   callback: (...args: Args) => void,
   wait: number,
-  options?: DebounceOptions,
 ) {
   const callbackRef = useRef(callback);
   useEffect(() => {
     callbackRef.current = callback;
   }, [callback]);
 
-  const rawEdges = options?.edges;
-  // debounce 側 default (["trailing"]) と整合させる
-  const hasLeading = rawEdges?.includes("leading") ?? false;
-  const hasTrailing = rawEdges?.includes("trailing") ?? true;
-  const signal = options?.signal;
-  const maxWait = options?.maxWait;
-
   const debouncedFn = useMemo(() => {
     const invokeLatest = (...args: Args) => {
       callbackRef.current(...args);
     };
-    const edges: Array<"leading" | "trailing"> = [];
-    if (hasLeading) {
-      edges.push("leading");
-    }
-    if (hasTrailing) {
-      edges.push("trailing");
-    }
     // ref は debounce のタイマーから非同期に読まれるだけで、レンダリング中には評価しない
     // oxlint-disable-next-line react-compiler-rules/refs
-    return debounce(invokeLatest, wait, { edges, signal, maxWait });
-  }, [hasLeading, hasTrailing, maxWait, signal, wait]);
+    return debounce(invokeLatest, wait);
+  }, [wait]);
 
   useEffect(() => {
     return () => {
-      debouncedFn.dispose();
+      debouncedFn.cancel();
     };
   }, [debouncedFn]);
 

--- a/src/utils/debounce/debounce.test.ts
+++ b/src/utils/debounce/debounce.test.ts
@@ -4,7 +4,7 @@ describe(debounce, () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  describe("trailing (default)", () => {
+  describe("基本動作 (trailing)", () => {
     it("待機時間後に1回だけ実行されること", () => {
       const fn = vi.fn();
       const debounced = debounce(fn, 100);
@@ -57,22 +57,6 @@ describe(debounce, () => {
       expect(fn).toHaveBeenCalledExactlyOnceWith(1, "two", { three: 3 });
     });
 
-    it("edges 未指定と edges: ['trailing'] が同一の動作をすること", () => {
-      const fn1 = vi.fn();
-      const fn2 = vi.fn();
-      const d1 = debounce(fn1, 100);
-      const d2 = debounce(fn2, 100, { edges: ["trailing"] });
-
-      d1("a");
-      d2("a");
-      expect(fn1).not.toHaveBeenCalled();
-      expect(fn2).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(100);
-      expect(fn1).toHaveBeenCalledExactlyOnceWith("a");
-      expect(fn2).toHaveBeenCalledExactlyOnceWith("a");
-    });
-
     it("連続するバーストが独立して処理されること", () => {
       const fn = vi.fn();
       const debounced = debounce(fn, 100);
@@ -88,298 +72,6 @@ describe(debounce, () => {
     });
   });
 
-  describe("leading", () => {
-    it("最初の呼び出しで即座に実行されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("first");
-      expect(fn).toHaveBeenCalledExactlyOnceWith("first");
-    });
-
-    it("待機中の連続呼び出しは無視されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced();
-      debounced();
-      debounced();
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it("待機中に再呼び出しするとクールダウンが延長されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("a");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(80);
-      debounced("b");
-
-      // 最初の呼び出しから100ms経過してもクールダウンが延長されている
-      vi.advanceTimersByTime(80);
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // 最後の再呼び出しから100ms後にクールダウン完了
-      vi.advanceTimersByTime(100);
-      debounced("d");
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "d");
-    });
-
-    it("待機時間後に再び leading 実行できること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("a");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(100);
-
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-
-    it("保留中のタイマーがあれば flush で即時実行されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("a");
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // flush は edges に関係なく「保留中のタイマーがあれば lastArgs で即実行」
-      debounced.flush();
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-
-    it("flush 後に再び leading が発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("a");
-      debounced("b");
-      debounced.flush();
-      expect(fn).toHaveBeenCalledTimes(2);
-
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(3);
-      expect(fn).toHaveBeenNthCalledWith(3, "c");
-    });
-
-    it("leading コールバック内から再帰呼び出ししても leading が二重発火しないこと", () => {
-      const calls: string[] = [];
-      const callback = vi.fn<(x: string) => void>((x) => {
-        calls.push(x);
-      });
-      const debounced = debounce(callback, 100, { edges: ["leading"] });
-
-      // 1 回目の invoke だけ再帰呼び出しする
-      callback.mockImplementationOnce((x) => {
-        calls.push(x);
-        debounced("re-entry");
-      });
-
-      debounced("a");
-      // 再帰呼び出しは isLeadingInvoked ガードにより leading 発火せず
-      expect(calls).toStrictEqual(["a"]);
-
-      // leading-only のため trailing も発火しない
-      vi.advanceTimersByTime(100);
-      expect(calls).toStrictEqual(["a"]);
-    });
-
-    it("クールダウン完了後に schedule→flush しても stale な引数で実行されないこと", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("stale");
-      debounced("stale2");
-
-      // クールダウン完了 → タイマーコールバックで lastArgs がクリアされる
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // lastArgs が残っていると schedule → flush で stale な引数で実行されてしまう
-      debounced.schedule();
-      debounced.flush();
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("leading + trailing", () => {
-    it("先頭と末尾の両方で実行されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      expect(fn).toHaveBeenCalledExactlyOnceWith("a");
-
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-
-    it("1回だけの呼び出しでは leading のみ実行されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("only");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("leading + trailing (edge cases)", () => {
-    it("3回以上のバーストで trailing が最後の引数を使うこと", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      debounced("b");
-      debounced("c");
-      expect(fn).toHaveBeenCalledExactlyOnceWith("a");
-
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "c");
-    });
-
-    it("flush で待機中の trailing を即時実行できること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      debounced.flush();
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-
-    it("cancel すると trailing が発火しないこと", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      debounced.cancel();
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it("cancel 後に新しいサイクルで leading が発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      debounced("b");
-      debounced.cancel();
-
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "c");
-    });
-
-    it("flush 後に新しいサイクルで leading が発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      debounced("b");
-      debounced.flush();
-      expect(fn).toHaveBeenCalledTimes(2);
-
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(3);
-      expect(fn).toHaveBeenNthCalledWith(3, "c");
-    });
-
-    it("クールダウン後に再バーストすると leading が再発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      // --- cycle 1: leading + trailing が両方発火
-      debounced("a1");
-      debounced("a2");
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(2);
-
-      // --- cycle 2: クールダウン解除後、再び leading が発火
-      debounced("b1");
-      expect(fn).toHaveBeenCalledTimes(3);
-      expect(fn).toHaveBeenNthCalledWith(3, "b1");
-
-      debounced("b2");
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(4);
-      expect(fn).toHaveBeenNthCalledWith(4, "b2");
-    });
-  });
-
-  describe("edges 共通の flush 挙動", () => {
-    it.for<{ name: string; edges: Array<"leading" | "trailing"> }>([
-      { name: "leading", edges: ["leading"] },
-      { name: "leading+trailing", edges: ["leading", "trailing"] },
-    ])(
-      "$name で1回だけの呼び出し後に flush しても追加実行されないこと",
-      ({ edges }) => {
-        const fn = vi.fn();
-        const debounced = debounce(fn, 100, { edges });
-
-        debounced("only");
-        expect(fn).toHaveBeenCalledExactlyOnceWith("only");
-
-        // タイマーは存在するが lastArgs は leading の invoke で消費済み
-        debounced.flush();
-        expect(fn).toHaveBeenCalledTimes(1);
-      },
-    );
-  });
-
-  describe("edges: []", () => {
-    it("空配列の場合は実行されないこと", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: [] });
-
-      debounced();
-      vi.advanceTimersByTime(100);
-
-      expect(fn).not.toHaveBeenCalled();
-    });
-  });
-
   describe("wait: 0", () => {
     it("タイマー発火時に実行されること", () => {
       const fn = vi.fn();
@@ -390,171 +82,6 @@ describe(debounce, () => {
 
       vi.advanceTimersByTime(0);
       expect(fn).toHaveBeenCalledExactlyOnceWith("zero");
-    });
-
-    it("leading モードで即座に実行されクールダウン後に再実行できること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 0, { edges: ["leading"] });
-
-      debounced("a");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // クールダウン中は無視
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // 0ms タイマー発火でクールダウン完了
-      vi.advanceTimersByTime(0);
-
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "c");
-    });
-
-    it("leading+trailing モードで両方実行されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 0, { edges: ["leading", "trailing"] });
-
-      debounced("a");
-      debounced("b");
-      expect(fn).toHaveBeenCalledExactlyOnceWith("a");
-
-      vi.advanceTimersByTime(0);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-  });
-
-  describe("再帰呼び出し", () => {
-    it("trailing コールバック内から再帰呼び出しした引数が失われないこと", () => {
-      const calls: string[] = [];
-      const callback = vi.fn<(x: string) => void>((x) => {
-        calls.push(x);
-      });
-      const debounced = debounce(callback, 100);
-
-      callback.mockImplementationOnce((x) => {
-        calls.push(x);
-        debounced("re-entry");
-      });
-
-      debounced("a");
-      vi.advanceTimersByTime(100);
-      expect(calls).toStrictEqual(["a"]);
-
-      // "re-entry" の trailing が発火するべき
-      vi.advanceTimersByTime(100);
-      expect(calls).toStrictEqual(["a", "re-entry"]);
-    });
-
-    it("leading+trailing コールバック内から再帰呼び出しした引数が trailing で実行されること", () => {
-      const calls: string[] = [];
-      const callback = vi.fn<(x: string) => void>((x) => {
-        calls.push(x);
-      });
-      const debounced = debounce(callback, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      callback.mockImplementationOnce((x) => {
-        calls.push(x);
-        debounced("re-entry");
-      });
-
-      debounced("a");
-      expect(calls).toStrictEqual(["a"]);
-
-      vi.advanceTimersByTime(100);
-      expect(calls).toStrictEqual(["a", "re-entry"]);
-    });
-  });
-
-  describe("例外復旧", () => {
-    it("コールバックが例外を投げても次のサイクルが動作すること", () => {
-      const fn = vi.fn().mockImplementationOnce(() => {
-        throw new Error("boom");
-      });
-      const debounced = debounce(fn, 100);
-
-      debounced("a");
-      expect(() => {
-        vi.advanceTimersByTime(100);
-      }).toThrow("boom");
-
-      debounced("b");
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-
-    it("leading モードでコールバックが例外を投げても次のサイクルが動作すること", () => {
-      const fn = vi.fn().mockImplementationOnce(() => {
-        throw new Error("boom");
-      });
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      expect(() => {
-        debounced("a");
-      }).toThrow("boom");
-
-      vi.advanceTimersByTime(100);
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
-
-    it("flush 中にコールバックが例外を投げても isLeadingInvoked がリセットされること", () => {
-      const fn = vi
-        .fn()
-        .mockImplementationOnce(() => {
-          // leading: 正常
-        })
-        .mockImplementationOnce(() => {
-          throw new Error("boom");
-        });
-      const debounced = debounce(fn, 100, { edges: ["leading", "trailing"] });
-
-      debounced("a");
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // flush の invoke で例外
-      expect(() => {
-        debounced.flush();
-      }).toThrow("boom");
-
-      // flush 内の例外後も isLeadingInvoked がリセットされ、新しいサイクルで leading が発火する
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(3);
-      expect(fn).toHaveBeenNthCalledWith(3, "c");
-    });
-
-    it("タイマーコールバック中にコールバックが例外を投げても isLeadingInvoked がリセットされること", () => {
-      const fn = vi
-        .fn()
-        .mockImplementationOnce(() => {
-          // leading: 正常
-        })
-        .mockImplementationOnce(() => {
-          throw new Error("boom");
-        });
-      const debounced = debounce(fn, 100, {
-        edges: ["leading", "trailing"],
-      });
-
-      debounced("a");
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // trailing の invoke で例外
-      expect(() => {
-        vi.advanceTimersByTime(100);
-      }).toThrow("boom");
-
-      // タイマーコールバック中の例外後も isLeadingInvoked がリセットされている
-      debounced("c");
-      expect(fn).toHaveBeenCalledTimes(3);
-      expect(fn).toHaveBeenNthCalledWith(3, "c");
     });
   });
 
@@ -591,20 +118,6 @@ describe(debounce, () => {
         debounced.cancel();
       }).not.toThrow();
     });
-
-    it("leading モードで cancel 後に再び leading が発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      debounced("a");
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      debounced.cancel();
-
-      debounced("b");
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "b");
-    });
   });
 
   describe("flush", () => {
@@ -627,6 +140,20 @@ describe(debounce, () => {
       vi.advanceTimersByTime(100);
 
       expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("flush 後に新しいサイクルを開始できること", () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100);
+
+      debounced("first");
+      debounced.flush();
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      debounced("second");
+      vi.advanceTimersByTime(100);
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn).toHaveBeenNthCalledWith(2, "second");
     });
 
     it.for<{
@@ -663,15 +190,6 @@ describe(debounce, () => {
         },
       },
       {
-        state: "cancel 後に schedule 済み (stale args 排除)",
-        setup: (d) => {
-          d("stale");
-          d.cancel();
-          d.schedule();
-          return 0;
-        },
-      },
-      {
         state: "サイクル自然完了後",
         setup: (d) => {
           d("data");
@@ -690,214 +208,158 @@ describe(debounce, () => {
       }).not.toThrow();
       expect(fn).toHaveBeenCalledTimes(expectedBefore);
     });
+  });
 
-    it("flush 後に新しいサイクルを開始できること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100);
+  describe("再帰呼び出し", () => {
+    it("コールバック内から再帰呼び出しした引数が次サイクルで実行されること", () => {
+      const calls: string[] = [];
+      const callback = vi.fn<(x: string) => void>((x) => {
+        calls.push(x);
+      });
+      const debounced = debounce(callback, 100);
 
-      debounced("first");
-      debounced.flush();
-      expect(fn).toHaveBeenCalledTimes(1);
+      // 1 回目の invoke だけ再帰呼び出しする
+      callback.mockImplementationOnce((x) => {
+        calls.push(x);
+        debounced("re-entry");
+      });
 
-      debounced("second");
+      debounced("a");
       vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "second");
+      expect(calls).toStrictEqual(["a"]);
+
+      // 再帰で予約された "re-entry" が次サイクルで発火する
+      vi.advanceTimersByTime(100);
+      expect(calls).toStrictEqual(["a", "re-entry"]);
     });
   });
 
-  describe("schedule", () => {
-    it("前回の引数でタイマーを再スケジュールすること", () => {
-      const fn = vi.fn();
+  describe("例外復旧", () => {
+    it("コールバックが例外を投げても次のサイクルが動作すること", () => {
+      const fn = vi.fn().mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
       const debounced = debounce(fn, 100);
 
-      // 50ms 経過 → schedule でタイマー再スケジュール → 追加 50ms ではまだ発火しない
-      debounced("args");
-      vi.advanceTimersByTime(50);
-      debounced.schedule();
-      vi.advanceTimersByTime(50);
-      expect(fn).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(50);
-      expect(fn).toHaveBeenCalledExactlyOnceWith("args");
-    });
-
-    it.for<{
-      state: string;
-      setup: (
-        d: ReturnType<typeof debounce<[string]>>,
-        fn: ReturnType<typeof vi.fn>,
-      ) => number;
-    }>([
-      { state: "初期状態 (保留無し)", setup: () => 0 },
-      {
-        state: "flush 済み",
-        setup: (d) => {
-          d("data");
-          d.flush();
-          return 1;
-        },
-      },
-      {
-        state: "cancel 済み",
-        setup: (d) => {
-          d("data");
-          d.cancel();
-          return 0;
-        },
-      },
-      {
-        state: "サイクル自然完了後",
-        setup: (d) => {
-          d("data");
-          vi.advanceTimersByTime(100);
-          return 1;
-        },
-      },
-    ])(
-      "$state からの schedule はタイマーを張らず invoke も発生しないこと",
-      ({ setup }) => {
-        const fn = vi.fn<(x: string) => void>();
-        const debounced = debounce(fn, 100);
-        const expectedBefore = setup(debounced, fn);
-        expect(fn).toHaveBeenCalledTimes(expectedBefore);
-        expect(vi.getTimerCount()).toBe(0);
-
-        debounced.schedule();
-        expect(vi.getTimerCount()).toBe(0);
-        vi.advanceTimersByTime(100);
-        expect(fn).toHaveBeenCalledTimes(expectedBefore);
-      },
-    );
-
-    it("schedule を連続で呼ぶと毎回タイマーがリセットされること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100);
-
-      // 50ms 刻みで schedule を繰り返すたびに 100ms タイマーが毎回リセットされる
-      debounced("args");
-      vi.advanceTimersByTime(50);
-      debounced.schedule();
-      vi.advanceTimersByTime(50);
-      debounced.schedule();
-      vi.advanceTimersByTime(50);
-      expect(fn).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(50);
-      expect(fn).toHaveBeenCalledExactlyOnceWith("args");
-    });
-
-    it("leading モードで schedule するとクールダウンが延長されること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { edges: ["leading"] });
-
-      // t=0: leading 発火、タイマー → t=100
       debounced("a");
-      expect(fn).toHaveBeenCalledTimes(1);
+      expect(() => {
+        vi.advanceTimersByTime(100);
+      }).toThrow("boom");
 
-      // t=80: schedule でタイマーリセット → t=180
-      vi.advanceTimersByTime(80);
-      debounced.schedule();
-
-      // t=180: リスケジュール分の100ms経過 → クールダウン完了
-      vi.advanceTimersByTime(100);
       debounced("b");
+      vi.advanceTimersByTime(100);
       expect(fn).toHaveBeenCalledTimes(2);
       expect(fn).toHaveBeenNthCalledWith(2, "b");
     });
   });
 
-  describe("signal", () => {
-    it("AbortSignal で保留中の実行がキャンセルされること", () => {
+  describe("エッジケース", () => {
+    it("多数回呼び出した後に flush すると最新の引数で実行されること", () => {
       const fn = vi.fn();
-      const controller = new AbortController();
-      const debounced = debounce(fn, 100, { signal: controller.signal });
-
-      debounced();
-      controller.abort();
-      vi.advanceTimersByTime(100);
-
-      expect(fn).not.toHaveBeenCalled();
-    });
-
-    it("abort 後は呼び出しが無視されること", () => {
-      const fn = vi.fn();
-      const controller = new AbortController();
-      const debounced = debounce(fn, 100, {
-        signal: controller.signal,
-        edges: ["leading"],
-      });
-
-      debounced();
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      controller.abort();
-
-      debounced();
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it.for<{ name: "schedule" | "flush" | "cancel" }>([
-      { name: "schedule" },
-      { name: "flush" },
-      { name: "cancel" },
-    ])(
-      "abort 後に $name を呼んでも実行されず例外も投げないこと",
-      ({ name }) => {
-        const fn = vi.fn();
-        const controller = new AbortController();
-        const debounced = debounce(fn, 100, { signal: controller.signal });
-
-        debounced("data");
-        controller.abort();
-
-        expect(() => {
-          debounced[name]();
-        }).not.toThrow();
-        vi.advanceTimersByTime(100);
-        expect(fn).not.toHaveBeenCalled();
-      },
-    );
-
-    it("既に abort 済みの signal を渡すと最初から無効であること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        signal: AbortSignal.abort(),
-      });
-
-      debounced();
-      vi.advanceTimersByTime(100);
-
-      expect(fn).not.toHaveBeenCalled();
-    });
-
-    it("既に abort 済みの signal + leading でも無効であること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, {
-        signal: AbortSignal.abort(),
-        edges: ["leading"],
-      });
-
-      debounced();
-      expect(fn).not.toHaveBeenCalled();
-    });
-
-    it("leading+trailing で leading 発火後に abort すると trailing が発火しないこと", () => {
-      const fn = vi.fn();
-      const controller = new AbortController();
-      const debounced = debounce(fn, 100, {
-        signal: controller.signal,
-        edges: ["leading", "trailing"],
-      });
+      const debounced = debounce(fn, 100);
 
       debounced("a");
       debounced("b");
-      expect(fn).toHaveBeenCalledTimes(1);
+      debounced("c");
+      debounced.flush();
 
-      controller.abort();
+      expect(fn).toHaveBeenCalledExactlyOnceWith("c");
+    });
+
+    it("wait:0 で連続呼び出ししても trailing で最後の引数1回だけ実行されること", () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 0);
+
+      debounced("a");
+      debounced("b");
+      expect(fn).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(0);
+      expect(fn).toHaveBeenCalledExactlyOnceWith("b");
+    });
+
+    it("コールバック内から flush を呼んでも二重実行・例外が起きないこと", () => {
+      const calls: string[] = [];
+      const fn = vi.fn<(x: string) => void>((x) => {
+        calls.push(x);
+      });
+      const debounced = debounce(fn, 100);
+
+      fn.mockImplementationOnce((x) => {
+        calls.push(x);
+        // run() で lastArgs はクリア済みなので flush は no-op になる
+        debounced.flush();
+      });
+
+      debounced("a");
+      expect(() => {
+        vi.advanceTimersByTime(100);
+      }).not.toThrow();
+      expect(calls).toStrictEqual(["a"]);
+
+      // 後続のタイマーも残っていない
       vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
+      expect(calls).toStrictEqual(["a"]);
+    });
+
+    it("コールバック内から cancel を呼んでも安全で、後続サイクルが動くこと", () => {
+      const fn = vi.fn<(x: string) => void>();
+      const debounced = debounce(fn, 100);
+
+      fn.mockImplementationOnce(() => {
+        // 1 回目の実行中に自分自身を cancel しても安全であることを確認する
+        expect(fn).toHaveBeenCalledTimes(1);
+        debounced.cancel();
+      });
+
+      debounced("a");
+      expect(() => {
+        vi.advanceTimersByTime(100);
+      }).not.toThrow();
+      expect(fn).toHaveBeenCalledExactlyOnceWith("a");
+
+      debounced("b");
+      vi.advanceTimersByTime(100);
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn).toHaveBeenNthCalledWith(2, "b");
+    });
+
+    it("flush 中にコールバックが例外を投げても次のサイクルが動作すること", () => {
+      const fn = vi.fn().mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      const debounced = debounce(fn, 100);
+
+      debounced("a");
+      expect(() => {
+        debounced.flush();
+      }).toThrow("boom");
+
+      // 例外後も状態が壊れず次サイクルが動く
+      debounced("b");
+      vi.advanceTimersByTime(100);
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn).toHaveBeenNthCalledWith(2, "b");
+    });
+
+    it("cancel 後に flush しても何も実行されないこと", () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100);
+
+      debounced("a");
+      debounced.cancel();
+      debounced.flush();
+      vi.advanceTimersByTime(100);
+
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("返り値が呼び出し可能で cancel/flush メソッドを持つこと", () => {
+      const debounced = debounce(() => {}, 100);
+
+      expect(debounced).toBeTypeOf("function");
+      expect(debounced.cancel).toBeTypeOf("function");
+      expect(debounced.flush).toBeTypeOf("function");
     });
   });
 
@@ -909,324 +371,8 @@ describe(debounce, () => {
         label: "wait が Infinity",
         create: () => debounce(() => {}, Number.POSITIVE_INFINITY),
       },
-      {
-        label: "maxWait が負数",
-        create: () => debounce(() => {}, 100, { maxWait: -1 }),
-      },
-      {
-        label: "maxWait が NaN",
-        create: () => debounce(() => {}, 100, { maxWait: Number.NaN }),
-      },
     ])("$label だと TypeError を投げること", ({ create }) => {
       expect(create).toThrow(TypeError);
-    });
-  });
-
-  describe("maxWait", () => {
-    it("maxWait 指定時、連続呼び出し中でも maxWait を超えた時点で発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50, { maxWait: 200 });
-
-      // 30ms 間隔で連続呼び出し (通常の debounce なら永遠に発火しない)
-      debounced("x");
-      for (let i = 0; i < 7; i += 1) {
-        vi.advanceTimersByTime(30);
-        debounced("x");
-      }
-      // t=210 到達時点で maxWait=200 の境界を超え、t=200 で正確に 1 回発火している
-      expect(fn).toHaveBeenCalledTimes(1);
-      expect(fn).toHaveBeenLastCalledWith("x");
-    });
-
-    it("maxWait 無しだと連続呼び出し中は発火しないこと (maxWait が効いていることを裏側から確認)", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50);
-
-      debounced();
-      for (let i = 0; i < 7; i += 1) {
-        vi.advanceTimersByTime(30);
-        debounced();
-      }
-      expect(fn).not.toHaveBeenCalled();
-    });
-
-    it("maxWait の発火は最後の引数を使うこと", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50, { maxWait: 100 });
-
-      debounced("a");
-      vi.advanceTimersByTime(30);
-      debounced("b");
-      vi.advanceTimersByTime(30);
-      debounced("c");
-      vi.advanceTimersByTime(30);
-      debounced("d");
-      // t=90 時点、maxWait=100 まで残り 10ms
-      vi.advanceTimersByTime(10);
-      // t=100 到達で maxWait 発火 → 最新の "d" で実行
-      expect(fn).toHaveBeenCalledExactlyOnceWith("d");
-    });
-
-    it("maxWait が wait 未満の場合は wait にクランプされること", () => {
-      const fn = vi.fn();
-      // maxWait(30) < wait(100) → maxWait は 100 にクランプ
-      const debounced = debounce(fn, 100, { maxWait: 30 });
-
-      debounced();
-      vi.advanceTimersByTime(99);
-      expect(fn).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(1);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it("leading-only + maxWait で maxWait 超過時に leading が再発火すること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50, {
-        maxWait: 150,
-        edges: ["leading"],
-      });
-
-      // t=0: leading で "a" 発火
-      debounced("a");
-      expect(fn).toHaveBeenCalledExactlyOnceWith("a");
-
-      // 30ms 刻みで 6 回 (計 180ms)。maxWait 超過でタイマーが t=150 に短縮され、
-      // そこでタイマーが発火して isLeadingInvoked がリセット → t=150 に呼ばれた x4 で leading 再発火
-      for (let i = 0; i < 6; i += 1) {
-        vi.advanceTimersByTime(30);
-        debounced(`x${i}`);
-      }
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenNthCalledWith(2, "x4");
-    });
-
-    it("1回呼んだ後に静止すれば、通常の debounce 発火のみで maxWait 発火は起きないこと", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50, { maxWait: 200 });
-
-      debounced("once");
-      vi.advanceTimersByTime(50);
-      expect(fn).toHaveBeenCalledExactlyOnceWith("once");
-
-      // 更に時間を進めても追加発火しない
-      vi.advanceTimersByTime(500);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it("自然発火後に長時間静止してから再呼び出ししても maxWait 強制発火が起きないこと (回帰テスト)", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50, { maxWait: 100 });
-
-      // 1回目のバースト
-      debounced("a");
-      vi.advanceTimersByTime(50);
-      expect(fn).toHaveBeenCalledExactlyOnceWith("a");
-
-      // 長時間静止 (前回 invoke から 1000ms が経過、maxWait(100) より遥かに大きい)
-      vi.advanceTimersByTime(1000);
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // 2回目のバースト: 新規 baseline で通常の debounce(50ms) 後に発火すべき
-      debounced("b");
-      vi.advanceTimersByTime(49);
-      // バグ時: 強制 maxWait で即時発火していた
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(1);
-      expect(fn).toHaveBeenCalledTimes(2);
-      expect(fn).toHaveBeenLastCalledWith("b");
-    });
-
-    it("システム時刻が maxWait を超えて進んでも delay=0 にクランプされ invoke が走ること", () => {
-      const fn = vi.fn();
-      vi.setSystemTime(1000);
-      const debounced = debounce(fn, 50, { maxWait: 100 });
-
-      // baseline=1000, timer は 50ms 後に発火予定
-      debounced("x");
-
-      // システム時刻だけ進める (fake timer のキューは進まない)
-      vi.setSystemTime(2000);
-
-      // ここで schedule() が呼ばれると maxRemaining = 100 - (2000-1000) = -900 ≤ 0 のブランチに入り、
-      // delay=0, maxWaitForced=true で即時発火予約される
-      debounced("y");
-      vi.advanceTimersByTime(0);
-
-      expect(fn).toHaveBeenCalledExactlyOnceWith("y");
-    });
-
-    it("cancel で maxWait のベースライン (lastInvokeTime) がリセットされること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 50, { maxWait: 100 });
-
-      // 40ms 刻みで呼び出し、通常の trailing (50ms) を先送り
-      debounced();
-      vi.advanceTimersByTime(40);
-      debounced();
-      vi.advanceTimersByTime(40);
-      // t=80 時点、maxWait=100 の境界手前
-      debounced.cancel();
-      expect(fn).not.toHaveBeenCalled();
-
-      // cancel 後の新しいバーストでは fresh な maxWait が適用
-      debounced("b");
-      vi.advanceTimersByTime(49);
-      expect(fn).not.toHaveBeenCalled();
-      vi.advanceTimersByTime(1);
-      expect(fn).toHaveBeenCalledExactlyOnceWith("b");
-    });
-  });
-
-  describe("this コンテキスト", () => {
-    it("メソッド呼び出し時の this が func に伝搬されること", () => {
-      const spy = vi.fn();
-      const obj = {
-        value: 42,
-        update: debounce(function update(this: { value: number }, v: number) {
-          spy(this.value, v);
-        }, 100),
-      };
-
-      obj.update(10);
-      vi.advanceTimersByTime(100);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(42, 10);
-    });
-
-    it("leading モードでも this が func に伝搬されること", () => {
-      const spy = vi.fn();
-      const obj = {
-        value: 99,
-        update: debounce(
-          function update(this: { value: number }, v: number) {
-            spy(this.value, v);
-          },
-          100,
-          { edges: ["leading"] },
-        ),
-      };
-
-      obj.update(7);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(99, 7);
-    });
-
-    it("Function.prototype.call で渡した this が使われ、最後の this が優先されること", () => {
-      const spy = vi.fn();
-      const debounced = debounce(function fn(this: { x: number }) {
-        spy(this.x);
-      }, 100);
-
-      debounced.call({ x: 1 });
-      debounced.call({ x: 2 });
-      vi.advanceTimersByTime(100);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(2);
-    });
-
-    it("cancel で保持された this がクリアされ、以降のサイクルに漏れないこと", () => {
-      const spy = vi.fn();
-      const debounced = debounce(function fn(this: { x: number } | undefined) {
-        spy(this?.x);
-      }, 100);
-
-      debounced.call({ x: 1 });
-      debounced.cancel();
-
-      // 新しいサイクルを別の this で開始
-      debounced.call({ x: 2 });
-      vi.advanceTimersByTime(100);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(2);
-    });
-
-    it("再帰呼び出し時に保存した this が失われないこと", () => {
-      const spy = vi.fn();
-      const callback = vi.fn<(this: { value: number }, step: number) => void>(
-        function defaultImpl(this: { value: number }, step) {
-          spy(this.value, step);
-        },
-      );
-      const obj = {
-        value: 1,
-        update: debounce(callback, 100),
-      };
-
-      // 1 回目の trailing 実行中だけ再帰呼び出しする
-      callback.mockImplementationOnce(
-        function recursingImpl(this: { value: number }, step) {
-          spy(this.value, step);
-          obj.update(2);
-        },
-      );
-
-      obj.update(1);
-      vi.advanceTimersByTime(100);
-      expect(spy).toHaveBeenNthCalledWith(1, 1, 1);
-
-      // 再帰で予約された trailing も同じ this で発火すべき
-      vi.advanceTimersByTime(100);
-      expect(spy).toHaveBeenNthCalledWith(2, 1, 2);
-    });
-  });
-
-  describe("dispose", () => {
-    it("dispose 後の呼び出しと flush/schedule/cancel が no-op になること", () => {
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100);
-
-      debounced("a");
-      debounced.dispose();
-
-      debounced("b");
-      debounced.flush();
-      debounced.schedule();
-      debounced.cancel();
-      vi.advanceTimersByTime(100);
-
-      expect(fn).not.toHaveBeenCalled();
-    });
-
-    it("コールバック内で dispose を呼んでも例外にならず、以降の schedule が no-op になること", () => {
-      const fn = vi.fn<(x: string) => void>();
-      // oxlint-disable-next-line prefer-const
-      let debounced: ReturnType<typeof debounce<[string]>>;
-      fn.mockImplementation(() => {
-        debounced.dispose();
-      });
-      debounced = debounce(fn, 100, { edges: ["leading", "trailing"] });
-
-      expect(() => {
-        debounced("a");
-      }).not.toThrow();
-      expect(fn).toHaveBeenCalledTimes(1);
-
-      // dispose 後は trailing も発火せず、以降の呼び出しも無視される
-      vi.advanceTimersByTime(100);
-      debounced("b");
-      vi.advanceTimersByTime(100);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it("dispose が外部 signal の abort リスナを解除すること", () => {
-      const controller = new AbortController();
-      const addSpy = vi.spyOn(controller.signal, "addEventListener");
-      const fn = vi.fn();
-      const debounced = debounce(fn, 100, { signal: controller.signal });
-
-      // listener が登録された際の options を取得
-      expect(addSpy).toHaveBeenCalledTimes(1);
-      const [addCall] = addSpy.mock.calls;
-      const listenerOptions = addCall[2] as AddEventListenerOptions;
-      expect(listenerOptions.signal?.aborted).toBe(false);
-
-      debounced.dispose();
-
-      // dispose により teardown signal が abort され、abort リスナが解除される
-      expect(listenerOptions.signal?.aborted).toBe(true);
-
-      // 念のため: abort しても debounced は発火しない
-      controller.abort();
-      vi.advanceTimersByTime(100);
-      expect(fn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/debounce/debounce.ts
+++ b/src/utils/debounce/debounce.ts
@@ -1,35 +1,9 @@
-export interface DebounceOptions {
-  /**
-   * Abort 時に保留中の呼び出しをキャンセルし、以降の呼び出しを無効化する。
-   * debounced インスタンスより寿命の長い signal を渡す場合は、不要になった時点で
-   * `debounced.dispose()` を呼ぶと signal 上の abort リスナが解除される。
-   */
-  signal?: AbortSignal;
-  edges?: Array<"leading" | "trailing">;
-  /**
-   * 連続呼び出し中でも最低 `maxWait` ms 以内に必ず `func` が実行されることを保証する。
-   * `wait` 未満の値は `wait` にクランプされる。
-   */
-  maxWait?: number;
-}
-
-/** @public */
-export interface DebouncedFunction<Args extends unknown[]> {
+interface DebouncedFunction<Args extends unknown[]> {
   (...args: Args): void;
-  /**
-   * 現在の lastArgs でタイマーを再スケジュールする。引数が未設定の場合はタイマー発火時に何も実行されない。leading
-   * のクールダウン状態はリセットしない。
-   */
-  schedule: () => void;
   /** 保留中のタイマーをクリアし、内部状態をリセットする。 */
   cancel: () => void;
   /** 保留中のコールバックを即時実行する。保留がなければ何もしない。 */
   flush: () => void;
-  /**
-   * 保留中のコールバックをキャンセルし、外部 `signal` に登録した abort リスナを解除して
-   * 以降すべての呼び出しを no-op 化する。コンポーネントのアンマウント時などに呼ぶ。
-   */
-  dispose: () => void;
 }
 
 function assertNonNegativeFinite(name: string, value: number): void {
@@ -43,160 +17,43 @@ function assertNonNegativeFinite(name: string, value: number): void {
 export function debounce<Args extends unknown[]>(
   func: (...args: Args) => void,
   wait: number,
-  options?: DebounceOptions,
 ): DebouncedFunction<Args> {
   assertNonNegativeFinite("wait", wait);
 
-  const edges = options?.edges ?? ["trailing"];
-  const hasLeading = edges.includes("leading");
-  const hasTrailing = edges.includes("trailing");
-
-  const rawMaxWait = options?.maxWait;
-  if (rawMaxWait !== undefined) {
-    assertNonNegativeFinite("maxWait", rawMaxWait);
-  }
-  // lodash 互換: maxWait < wait は wait にクランプ
-  const maxWait =
-    rawMaxWait === undefined ? undefined : Math.max(rawMaxWait, wait);
-
   let timerId: ReturnType<typeof setTimeout> | undefined = undefined;
   let lastArgs: Args | undefined = undefined;
-  let lastThis: unknown = undefined;
-  // maxWait の経過判定に使う基準時刻。
-  // 新規バースト開始時と invoke 時に `Date.now()` で更新する。
-  let baselineTime: number | undefined = undefined;
-  let isLeadingInvoked = false;
-  let isAborted = options?.signal?.aborted ?? false;
 
-  function invoke() {
-    if (lastArgs !== undefined) {
-      const args = lastArgs;
-      const thisArg = lastThis;
-      // 先に内部状態をクリアすることで、func 内からの再帰呼び出しで
-      // 設定された lastArgs/lastThis を上書きしない
-      lastArgs = undefined;
-      lastThis = undefined;
-      baselineTime = Date.now();
-      func.apply(thisArg, args);
-    }
+  // func 実行前に内部状態をクリアする。これにより:
+  // - 再帰: func 内から debounced() を呼んでも保持中の引数を上書きしない
+  // - 例外復旧: func が throw しても timerId/lastArgs はクリア済みで次サイクルが動く
+  function run(args: Args) {
+    timerId = undefined;
+    lastArgs = undefined;
+    func(...args);
   }
 
+  // clearTimeout は undefined を渡しても no-op なので、timerId の有無を分岐しない。
   function cancel() {
-    if (timerId !== undefined) {
-      clearTimeout(timerId);
-      timerId = undefined;
-    }
+    clearTimeout(timerId);
+    timerId = undefined;
     lastArgs = undefined;
-    lastThis = undefined;
-    baselineTime = undefined;
-    isLeadingInvoked = false;
   }
 
   function flush() {
-    if (isAborted || timerId === undefined) {
+    if (lastArgs === undefined) {
       return;
     }
     clearTimeout(timerId);
-    timerId = undefined;
-    try {
-      invoke();
-    } finally {
-      isLeadingInvoked = false;
-    }
+    run(lastArgs);
   }
 
-  function schedule() {
-    if (isAborted) {
-      return;
-    }
-    // 保留中の引数もクールダウン解除予定も無ければ、タイマーを張る意味が無い
-    if (lastArgs === undefined && !isLeadingInvoked) {
-      return;
-    }
-    if (timerId !== undefined) {
-      clearTimeout(timerId);
-    }
-
-    let delay = wait;
-    let maxWaitForced = false;
-    if (maxWait !== undefined && baselineTime !== undefined) {
-      const maxRemaining = maxWait - (Date.now() - baselineTime);
-      if (maxRemaining <= 0) {
-        delay = 0;
-        maxWaitForced = true;
-      } else if (maxRemaining < delay) {
-        delay = maxRemaining;
-      }
-    }
-
+  function debounced(...args: Args): void {
+    lastArgs = args;
+    clearTimeout(timerId);
     timerId = setTimeout(() => {
-      timerId = undefined;
-      try {
-        // maxWait の強制発火では hasTrailing=false でも invoke する
-        if (hasTrailing || maxWaitForced) {
-          invoke();
-        } else {
-          lastArgs = undefined;
-          lastThis = undefined;
-        }
-      } finally {
-        isLeadingInvoked = false;
-      }
-    }, delay);
+      run(args);
+    }, wait);
   }
 
-  // dispose 時に signal listener を解除するための内部 controller
-  const teardown = new AbortController();
-
-  function dispose() {
-    cancel();
-    isAborted = true;
-    teardown.abort();
-  }
-
-  const debounced: DebouncedFunction<Args> = Object.assign(
-    function invokeDebounced(this: unknown, ...args: Args) {
-      if (isAborted) {
-        return;
-      }
-
-      lastArgs = args;
-      // 呼び出し側の this を func 発火時まで保持する (ラッパーの本質)
-      // oxlint-disable-next-line no-this-alias, no-this-assignment
-      lastThis = this;
-
-      // 新しいバーストの開始: maxWait のベースラインを更新
-      // (前回の invoke から時間が経った後の呼び出しが誤って maxWait 強制発火扱いに
-      // なるのを防ぐため、毎バーストで baselineTime を再設定する)
-      if (timerId === undefined) {
-        baselineTime = Date.now();
-      }
-
-      if (hasLeading && !isLeadingInvoked) {
-        isLeadingInvoked = true;
-        try {
-          invoke();
-        } finally {
-          schedule();
-        }
-        return;
-      }
-
-      schedule();
-    },
-    { schedule, cancel, flush, dispose },
-  );
-
-  if (options?.signal && !isAborted) {
-    options.signal.addEventListener(
-      "abort",
-      () => {
-        cancel();
-        isAborted = true;
-      },
-      { once: true, signal: teardown.signal },
-    );
-  }
-
-  return debounced;
+  return Object.assign(debounced, { cancel, flush });
 }

--- a/src/utils/debounce/index.ts
+++ b/src/utils/debounce/index.ts
@@ -1,6 +1,1 @@
-export {
-  debounce,
-  type DebounceOptions,
-  /** @public */
-  type DebouncedFunction,
-} from "./debounce";
+export { debounce } from "./debounce";


### PR DESCRIPTION
## 概要

汎用 `debounce` を実利用実態（消費者は `useDebouncedCallback` のみ・呼び出し元はサンドボックスの trailing-only 利用）に合わせてシンプル化し、死に分岐を排除して**カバレッジ 100%** を達成しました。lodash 互換を志向した「持ち過ぎ」状態の解消です。

## 変更点

### `debounce`
- **撤廃**: `leading` / `maxWait` / `signal` / `dispose` / `schedule` / `this` 伝搬 / `options` 引数 / `DebounceOptions` 型
- **残す**: trailing 発火 + `cancel()` + `flush()` + `wait` バリデーション（負数・NaN・Infinity → `TypeError`）
- `func` 実行前に内部状態をクリアする規律で、**再帰安全・例外復旧・flush 空 no-op** を担保
- `clearTimeout(undefined)` の no-op 性を使い**到達不能な分岐を排除**（branch 100%、ignore コメント不使用）
- 実装 202 行 → 約 60 行

### `useDebouncedCallback`
- `options` 引数を撤廃、`useMemo` 依存を `[wait]` に
- cleanup を `dispose()` → `cancel()` に変更（インライン関数対応の最新参照 ref は維持）

### stories
- `Default`（純粋な debounce デモ）と `WithIme`（IME 対応）に分割し関心を分離
- **IME バグ修正**: `WithIme` の変換判定を、同期イベント内で 1 テンポ古くなる `useIsComposing()` スナップショットから、**発火時刻に正確な `nativeEvent.isComposing`** に変更。`onCompositionEnd` の `flush()` が確実に即時反映されるように
- 入力欄を上・結果表示を下のレイアウトに調整

## テスト / 検証
- debounce 29 件 + フック 8 件 + story 2 件（Default/WithIme smoke）
- 対象 2 ファイル **カバレッジ 100%**（Stmts/Branch/Func/Lines）
- フルスイート **494 件パス**・型エラーなし・`pnpm check`（Oxlint + Oxfmt + Knip）クリーン

## BREAKING CHANGE
`debounce` の `options` 引数・`DebounceOptions` 型、`leading`/`maxWait`/`signal`/`dispose`/`schedule`・`this` 伝搬を削除。現状の利用箇所（`useDebouncedCallback`）は本 PR 内で追従済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)