### PR TITLE
chore: drop dead react-compiler-rules refs from config drift test

### DIFF
--- a/tools/oxlint-rules/oxlint.config.test.ts
+++ b/tools/oxlint-rules/oxlint.config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import oxlintConfig from "../../oxlint.config.ts";
 
-// 外部 jsPlugin（tanstack / storybook / react-hooks）は config にルールを手動列挙しているため、
+// 外部 jsPlugin（tanstack / storybook）は config にルールを手動列挙しているため、
 // プラグイン更新で増えた新ルールを取りこぼしうる（前方ドリフト）。それを検出して採用/除外の判断を促す。
 // 実在しないルール名は oxlint が config パース時に弾くため、後方ドリフトは扱わない。
 
@@ -11,28 +11,9 @@ interface PluginLike {
 type JsPluginEntry = string | { name?: string; specifier: string };
 
 // config に載せない外部ルールと、その理由。
-const IGNORED_RULES = new Set<string>([
-  // oxlint native の react ルールと重複
-  "react-compiler-rules/rules-of-hooks",
-  "react-compiler-rules/hooks",
-  "react-compiler-rules/exhaustive-deps",
-  // 依存検証（opt-in）。React Compiler 有効環境では不要
-  "react-compiler-rules/memo-dependencies",
-  "react-compiler-rules/exhaustive-effect-dependencies",
-  // コンパイラ内部診断でコード規則ではない
-  "react-compiler-rules/invariant",
-  "react-compiler-rules/todo",
-  // fbt（Meta の i18n）未使用
-  "react-compiler-rules/fbt",
-  // 削除済み（deprecated）
-  "react-compiler-rules/component-hook-factories",
-  // gating モード未使用
-  "react-compiler-rules/gating",
-  // 正当な suppression まで禁じるため不採用
-  "react-compiler-rules/rule-suppression",
-  // 構文診断系でノイズになりうる
-  "react-compiler-rules/syntax",
-]);
+// 現状は tanstack / storybook の全公開ルールを config に列挙済みのため空。
+// triage の結果「採用しない」と判断した外部ルールはここに理由付きで追加する。
+const IGNORED_RULES = new Set<string>();
 
 // プラグイン specifier → oxlint の前缀（eslint-plugin-x → x ／ @scope/eslint-plugin-x → @scope/x）。
 function stripEslintPluginPrefix(name: string): string {


### PR DESCRIPTION
## 背景

#2892 で oxlint 1.70.0 がネイティブの `react/react-compiler` ルールを実装したため、外部プラグイン `eslint-plugin-react-hooks`(alias `react-compiler-rules`)を削除した。しかし jsPlugin 整合テスト `tools/oxlint-rules/oxlint.config.test.ts` 側に、そのプラグインを指す参照が dead コードとして残っていた。

## 変更

- `IGNORED_RULES` から到達不能になった `react-compiler-rules/*`(13 件)を削除し空 Set に。前方ドリフト検出の仕組み自体は将来の triage 用に維持。
- ヘッダコメントの対象プラグイン列挙から `react-hooks` を除去(現状は `tanstack / storybook`)。

挙動変更なし(現状 tanstack / storybook の全公開ルールは config に列挙済みのため、空 Set でもテストは通る)。

## 確認

- `pnpm vitest run tools/oxlint-rules/oxlint.config.test.ts` → 3 passed
- pre-commit (oxlint / oxfmt / test) → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)