### PR TITLE
chore: optimize knip config and simplify postcss config

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,19 +1,11 @@
 {
   "$schema": "./node_modules/knip/schema-jsonc.json",
-  "ignore": ["src/**/openapi/**", "src/mocks/**"],
+  "ignore": ["src/api/openapi/**", "src/mocks/**"],
   "ignoreBinaries": ["openapiconfig.json", "actionlint", "zizmor"],
-  "ignoreDependencies": ["postcss-load-config"],
   "ignoreIssues": {
     "tools/oxlint-rules/*/*.ts": ["files"],
   },
-  "tailwind": {
-    "entry": ["src/lib/styles/globals.css"],
-  },
   "vitest": {
-    "entry": [
-      "**/*.{test,spec,test-d}.{ts,tsx}",
-      "vitest.globalSetup.ts",
-      "vitest.setup.ts",
-    ],
+    "entry": ["vitest.globalSetup.ts", "vitest.setup.ts"],
   },
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,4 +1,3 @@
-/** @type {import("postcss-load-config").Config} */
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},


### PR DESCRIPTION
## 概要

knip.jsonc を実証検証（各設定を1つずつ外して挙動を確認）した上で、無駄を削り、生成物ではない実ルートを解析対象に復帰させた。あわせて postcss config を簡素化した。

## 変更内容

### `knip.jsonc`
- **`ignore` の絞り込み**: `src/**/openapi/**` → `src/api/openapi/**`
  - openapi ディレクトリは2箇所存在: 生成物の `src/api/openapi/**` と、それを利用する**実ルート** `src/app/(sandbox)/openapi/**`
  - 旧パターンは後者まで巻き込んでデッドコード解析の対象外にしていた。絞り込みにより sandbox ルートが解析対象に復帰（`PostList.tsx` にダミー未使用 export を仕込むと検出されることを確認）
- **`tailwind` ブロック削除**: `globals.css` は `app/layout.tsx` の import 経由で到達可能なため、この entry 設定は無効果（files/exports/dependencies 全カテゴリで knip 出力に差分なしを確認）
- **`vitest.entry` の重複削除**: `**/*.{test,spec,test-d}.{ts,tsx}` は knip の vitest プラグイン既定 entry の部分集合のため冗長。`globalSetup.ts` / `setup.ts` は既定に無いため残置
- **`ignoreDependencies` 削除**: 下記 postcss の型注釈削除に伴い `postcss-load-config` への参照が消えたため不要に

### `postcss.config.mjs`
- `@type {import("postcss-load-config").Config}` の型注釈を削除（これが唯一の `postcss-load-config` 参照だった）

## 検証

- `pnpm knip`（`knip && knip --production`）両モード PASS
- `oxlint` / `oxfmt --check` PASS
- `pnpm build` 成功・PostCSS/Tailwind 警告なし、production CSS に Tailwind 出力（`--tw-*` 変数・ベンダープレフィックス）が含まれることを実測
- 公式ドキュメント（knip.dev）と照合し、残った各設定が推奨用途に対応していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)