### PR TITLE
chore(tsconfig): modernize compiler options for TypeScript 7

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,18 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noFallthroughCasesInSwitch": true,
     "jsx": "react-jsx",
     "incremental": true,
     "plugins": [


### PR DESCRIPTION
## 概要

typescript@7 移行（#2950）を受けた `tsconfig.json` の見直し。**追加した 4 項目はすべて `tsc --noEmit` が 0 エラーで通ることを実測して選定**している。見送ったフラグについても実測したエラー件数と内訳を根拠として残す。

## 追加

```diff
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "esnext",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noFallthroughCasesInSwitch": true,
```

| オプション | 理由 |
| --- | --- |
| `module: "preserve"` | bundler 前提プロジェクト向けの指定。`import` / `require` の混在を許容しつつ emit しない |
| `verbatimModuleSyntax` | type-only import/export の明示を強制し、bundler の挙動と型解析を一致させる |
| `noFallthroughCasesInSwitch` | `switch` の意図しない fallthrough を検出。現状 0 件なので事故防止の先行投資 |
| `lib` に `dom.iterable` | Next.js が生成する tsconfig の既定に含まれる。宣言の追加のみなのでエラーは増えない |

`moduleResolution` / `esModuleInterop` / `resolveJsonModule` は `module: "preserve"` が含意する値だが、`--showConfig` が明示設定の正規化サブセットしか出力せず含意を検証できなかったため、明示のまま残している。

## 見送ったフラグ（実測エラー件数と内訳）

| フラグ | エラー | 内訳 | 判断 |
| --- | --- | --- | --- |
| `erasableSyntaxOnly` | 10 | **全件** `src/api/openapi/runtime.ts` | 生成コード。`pnpm generate-api` で再生成されるため手修正が維持できない |
| `noImplicitOverride` | 1 | **全件** `src/api/openapi/runtime.ts` | 同上 |
| `noUnusedParameters` | 3 | **全件** `src/api/openapi/models/Post.ts` | 同上 |
| `noUnusedLocals` | 7 | 6 件が `src/app/(sandbox)/dummy/page.tsx` の `_isServer` / `_isKeyOf` など | 意図的な `_` プレフィックス変数。TS は locals の `_` 慣習を尊重しない。oxlint 側で担保済み |
| `noPropertyAccessFromIndexSignature` | 6 | `process.env.TURBOPACK`、`params.postId` など | ブラケット記法の強制は可読性を落とす割に得るものが薄い |
| `noUncheckedIndexedAccess` | 22 | 広範 | 方向性は良いが修正コスト大。段階導入を別途検討 |
| `exactOptionalPropertyTypes` | 23 | 広範 | 同上 |

## 副産物: `exclude` は生成コードを除外できていない

```json
"exclude": ["node_modules", "src/api/openapi"]
```

にもかかわらず `src/api/openapi/runtime.ts` / `models/Post.ts` から型エラーが出る。原因は `src/api/apiClient/apiClient.ts:1`:

```ts
import { Configuration, DefaultApi } from "../openapi";
```

**`exclude` は `include` の glob を絞るだけで、import されたファイルはプログラムに含まれる。** 生成コードは常に型チェック対象であり、上表の `erasableSyntaxOnly` / `noImplicitOverride` / `noUnusedParameters` を見送る根拠がこれ。

対処が必要になった場合の選択肢:

1. `pnpm generate-api` の後処理で `runtime.ts` に `// @ts-nocheck` を注入する（`generate-mock` が既に `sed` で後処理しているので前例あり）
2. 生成コードに引っかかるフラグは足さない（本 PR の方針）

## 補足: `plugins: [{ "name": "next" }]` の現状

`typescript@7` は**ネイティブバイナリのシム**で、`tsserver` を同梱していない:

```
node_modules/typescript/lib/ → getExePath.js, tsc.js, version.cjs のみ
optionalDependencies → @typescript/typescript-darwin-arm64 など 21 プラットフォーム
```

`plugins` は language service（tsserver）専用のオプションなので、TS7 を workspace version として選んだエディタでは Next プラグインは動かない。エディタ同梱の TS か TypeScript native preview 拡張を使っている場合のみ有効。害はないため本 PR では残している。

（`--showConfig` の出力から `plugins` と `noErrorTruncation` が消えるが、`--noErrorTruncation` を CLI フラグで渡してもエラーにならないので認識自体はされている。未知オプションなら `error TS5023` になることを対照実験で確認済み。）

## 検証

| コマンド | 結果 |
| --- | --- |
| `pnpm tsc --noEmit` | exit 0 |
| `pnpm check` | exit 0（oxlint / oxfmt / knip） |
| `pnpm test` | 57 files / **502 passed**、`Type Errors  no errors` |
| `pnpm build` | ✓ 成功 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
