### PR TITLE
fix(storybook): switch reactDocgen to react-docgen for TypeScript 7

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,7 +35,15 @@ const config: StorybookConfig = {
     disableTelemetry: true,
   },
   typescript: {
-    reactDocgen: "react-docgen-typescript",
+    // Storybook 既定の babel ベース docgen。精度の高い `react-docgen-typescript` は
+    // `ts.sys` など TypeScript の JS API を直接触るため、ネイティブ実装で JS API を
+    // 持たない typescript@7 では `build-storybook` が
+    // `TypeError: Cannot read properties of undefined (reading 'fileExists')` で落ちる。
+    // upstream は TS 7.1 の programmatic API (microsoft/typescript-go#2824, milestone
+    // Post-7.0) を待っている状態なので、それが着地するまでこちらを使う。
+    // 代償として `React.ComponentProps<"div">` や `VariantProps<typeof variants>` の
+    // 展開ができず、Docs の props テーブルの網羅性が落ちる。
+    reactDocgen: "react-docgen",
   },
   staticDirs: ["../public"],
 };


### PR DESCRIPTION
## 問題

typescript@7 移行（#2950）以降、**`pnpm build-storybook` が main で失敗している**。

```
TypeError: Cannot read properties of undefined (reading 'fileExists')
  at resolveTypescriptProject
  (@joshwooding/vite-plugin-react-docgen-typescript@0.7.0_typescript@7.0.2/dist/index.mjs:518:39)
  at async BasicMinimalPluginContext.configResolved
```

原因は `react-docgen-typescript` が `ts.sys` など TypeScript の JS API を直接 require していること。`typescript@7` はネイティブバイナリのシムで JS API を持たないため undefined になる:

```
node_modules/typescript/lib/ → getExePath.js, tsc.js, version.cjs のみ
```

upstream は TS 7.1 の programmatic API（[microsoft/TypeScript#63800](https://github.com/microsoft/TypeScript/issues/63800), milestone `Post-7.0`）待ちで停滞している。Storybook 側の新 docgen エンジン（`features.experimentalReactComponentMeta`）も Volar の language-core 経由で同じ `ts.createLanguageService` / `ts.sys` に依存するため、エンジン乗り換えでは解決しない（過去に実測済み）。

## 対応

Storybook 既定の babel ベース `react-docgen` に戻す。理由をコード内にコメントで残した。

```diff
   typescript: {
-    reactDocgen: "react-docgen-typescript",
+    // Storybook 既定の babel ベース docgen。精度の高い `react-docgen-typescript` は
+    // `ts.sys` など TypeScript の JS API を直接触るため、ネイティブ実装で JS API を
+    // 持たない typescript@7 では `build-storybook` が
+    // `TypeError: Cannot read properties of undefined (reading 'fileExists')` で落ちる。
+    // upstream は TS 7.1 の programmatic API (microsoft/TypeScript#63800, milestone
+    // Post-7.0) を待っている状態なので、それが着地するまでこちらを使う。
+    // 代償として `React.ComponentProps<"div">` や `VariantProps<typeof variants>` の
+    // 展開ができず、Docs の props テーブルの網羅性が落ちる。
+    reactDocgen: "react-docgen",
   },
```

## トレードオフの実測

ビルド成果物の `__docgenInfo` を実際に読んで劣化範囲を確認した。

| component | props テーブル | 未展開のまま `composes` に残った型 |
| --- | --- | --- |
| `Button` | 一部（`asChild` のみ） | `VariantProps` |
| `Field` | あり（`label` / `errorMessage` / `render`） | — |
| `Spinner` | 一部 | `Omit`, `VariantProps` |
| `SvgIcon` | 一部 | `Omit`, `SvgIconVariants` |
| `Card` | **空** | `VariantProps` |
| `Input` | **空** | `VariantProps` |
| `Label` | **空** | `VariantProps` |

- **残るもの**: ローカルに宣言したインターフェースメンバーと JSDoc の description
- **失われるもの**: `React.ComponentProps<"div">` や `VariantProps<typeof variants>` から来る行。`composes` に型名だけ記録され展開されない。Docs の props テーブルはこれをレンダリングしないため、合成のみで構成された `Card` / `Input` / `Label` は空表になる

`.claude/rules/components.md` の推奨パターンが

```ts
interface ComponentProps
  extends React.ComponentProps<"div">, VariantProps<typeof componentVariants> {}
```

なので、この構成では劣化が出やすい。網羅的な props ドキュメントが必要になったら、TS 公式が案内している side-by-side 構成（`"@typescript/native": "npm:typescript@^7"` + `"typescript": "npm:@typescript/typescript6@^6"`。`tsc` バイナリは 7、`require("typescript")` の API は 6 のまま）で `react-docgen-typescript` を復活させる余地がある。本 PR ではまず動く状態を優先した。

## 検証

| コマンド | 変更前 | 変更後 |
| --- | --- | --- |
| `pnpm build-storybook` | ❌ `TypeError: ... reading 'fileExists'` | ✅ **Storybook build completed successfully** |
| `pnpm test`（storybook プロジェクト含む） | ✅ | ✅ 57 files / **502 passed**、`Type Errors  no errors` |

CI は `build-storybook` を回していない（`.github/workflows/*.yml` に storybook の記述が 0 件）ため、CI 上の結果は変わらない。壊れていたのはローカル実行と Storybook を配信物としてビルドするケースのみ。`pnpm test` の storybook プロジェクトは docgen プラグインを経由しないため元から無傷だった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
